### PR TITLE
feat(notifications): email & Novu system audit + remediation

### DIFF
--- a/app/api/webhooks/stripe/handlers/payment.ts
+++ b/app/api/webhooks/stripe/handlers/payment.ts
@@ -2326,3 +2326,62 @@ export async function handlePaymentIntentRequiresAction(paymentIntent: Stripe.Pa
     }
   }
 }
+
+/**
+ * Handle `payment_intent.processing` — fires after a Multibanco voucher's
+ * 7-day payment window closes (transitioning the PI from `requires_action`
+ * to `processing`) or for any async payment method whose funds Stripe is
+ * still confirming. We don't change DB state here; the post-event Novu
+ * trigger in `triggerNovuNotificationFromStripeEvent` will deliver a
+ * "your payment is processing" notification to the patient via the
+ * `payment-universal` workflow with `eventType: 'pending'`.
+ *
+ * Without this handler, the event would log as "Unhandled event type"
+ * and the patient would only learn what happened 4 days later when the
+ * PI finally transitions to `succeeded` or `payment_failed`.
+ */
+export async function handlePaymentIntentProcessing(paymentIntent: Stripe.PaymentIntent) {
+  console.log(
+    `Payment intent ${paymentIntent.id} entered processing state. ` +
+      `Payment method type: ${paymentIntent.payment_method_types?.join(', ') || 'unknown'}`,
+  );
+  // Intentionally no DB writes — the slot reservation created at
+  // `requires_action` stays valid through the processing buffer. Stripe
+  // will resolve to `succeeded` or `payment_failed` within ~4 days.
+}
+
+/**
+ * Handle `payment_intent.canceled` — fires when the customer or our cron
+ * job (cleanup-expired-reservations) explicitly cancels a pending PI
+ * before it succeeds. Used to release the slot reservation early.
+ */
+export async function handlePaymentIntentCanceled(paymentIntent: Stripe.PaymentIntent) {
+  console.log(
+    `Payment intent ${paymentIntent.id} was canceled. Cancellation reason: ${
+      paymentIntent.cancellation_reason || 'unspecified'
+    }`,
+  );
+  // The actual reservation release happens in
+  // `app/api/cron/cleanup-expired-reservations` based on `expiresAt` and
+  // in `handleChargeRefunded` for refund-driven cancellations. This
+  // handler exists so the post-event Novu trigger fires (so we can send
+  // a "booking cancelled" email if appropriate) and so the event no
+  // longer logs as "Unhandled".
+}
+
+/**
+ * Handle `charge.dispute.updated` and `charge.dispute.closed` — Stripe
+ * recommends listening for status changes on top of `created` so internal
+ * state stays in sync as the dispute moves through `under_review` → `won`
+ * /`lost`/`warning_closed`. We log status changes; transfer status
+ * remains `disputed` until a follow-up business decision is made.
+ */
+export async function handleDisputeUpdated(dispute: Stripe.Dispute) {
+  console.log(
+    `Dispute ${dispute.id} status changed to "${dispute.status}". ` +
+      `Reason: ${dispute.reason || 'unspecified'}, amount: ${dispute.amount}.`,
+  );
+  // Intentionally minimal — the full lifecycle (refund handling, payout
+  // recovery) is better managed manually based on `dispute.status`.
+}
+

--- a/app/api/webhooks/stripe/handlers/payment.ts
+++ b/app/api/webhooks/stripe/handlers/payment.ts
@@ -2327,33 +2327,69 @@ export async function handlePaymentIntentRequiresAction(paymentIntent: Stripe.Pa
   }
 }
 
+// Stripe holds Multibanco funds in a settlement buffer (≈4 days) after a
+// voucher's 7-day payment window closes. The slot reservation was created
+// at `payment_intent.requires_action` with `expiresAt = voucherExpiresAt`,
+// so the cleanup cron (lt(expiresAt, now)) would otherwise free the slot
+// the moment the voucher expires — even though Stripe is still confirming
+// the payment. We push the reservation expiry forward by this buffer so
+// the slot stays held until Stripe resolves to `succeeded`/`payment_failed`.
+const MULTIBANCO_PROCESSING_BUFFER_MS = 4 * 24 * 60 * 60 * 1000;
+
 /**
  * Handle `payment_intent.processing` — fires after a Multibanco voucher's
  * 7-day payment window closes (transitioning the PI from `requires_action`
  * to `processing`) or for any async payment method whose funds Stripe is
- * still confirming. We don't change DB state here; the post-event Novu
- * trigger in `triggerNovuNotificationFromStripeEvent` will deliver a
- * "your payment is processing" notification to the patient via the
- * `payment-universal` workflow with `eventType: 'pending'`.
+ * still confirming.
  *
- * Without this handler, the event would log as "Unhandled event type"
- * and the patient would only learn what happened 4 days later when the
- * PI finally transitions to `succeeded` or `payment_failed`.
+ * We extend the matching slot-reservation's `expiresAt` by Stripe's
+ * settlement buffer so `cleanup-expired-reservations` doesn't free the
+ * slot during the buffer window. The post-event Novu trigger in
+ * `triggerNovuNotificationFromStripeEvent` separately delivers a
+ * "your payment is processing" notification to the patient.
  */
 export async function handlePaymentIntentProcessing(paymentIntent: Stripe.PaymentIntent) {
   console.log(
     `Payment intent ${paymentIntent.id} entered processing state. ` +
       `Payment method type: ${paymentIntent.payment_method_types?.join(', ') || 'unknown'}`,
   );
-  // Intentionally no DB writes — the slot reservation created at
-  // `requires_action` stays valid through the processing buffer. Stripe
-  // will resolve to `succeeded` or `payment_failed` within ~4 days.
+
+  try {
+    const newExpiresAt = new Date(Date.now() + MULTIBANCO_PROCESSING_BUFFER_MS);
+    const updated = await db
+      .update(SlotReservationTable)
+      .set({ expiresAt: newExpiresAt, updatedAt: new Date() })
+      .where(eq(SlotReservationTable.stripePaymentIntentId, paymentIntent.id))
+      .returning({ id: SlotReservationTable.id, expiresAt: SlotReservationTable.expiresAt });
+
+    if (updated.length > 0) {
+      console.log(
+        `🛡️ Extended slot reservation ${updated[0].id} expiresAt to ${updated[0].expiresAt.toISOString()} ` +
+          `to cover Stripe's settlement buffer for PI ${paymentIntent.id}`,
+      );
+    } else {
+      // No matching reservation — usually a card payment (no reservation
+      // was ever created since cards are sync). Safe to ignore.
+      console.log(
+        `No slot reservation found for PI ${paymentIntent.id} in processing state — likely a sync card payment`,
+      );
+    }
+  } catch (dbError) {
+    // Don't fail the webhook over a reservation-extension error; the cron
+    // will still free the slot at the original expiresAt if extension
+    // fails (degraded behavior, but webhook stays acked).
+    console.error(
+      `Failed to extend slot reservation for PI ${paymentIntent.id} during processing:`,
+      dbError,
+    );
+  }
 }
 
 /**
  * Handle `payment_intent.canceled` — fires when the customer or our cron
  * job (cleanup-expired-reservations) explicitly cancels a pending PI
- * before it succeeds. Used to release the slot reservation early.
+ * before it succeeds. Releases the slot reservation immediately so the
+ * patient doesn't have to wait for the cleanup cron's next tick.
  */
 export async function handlePaymentIntentCanceled(paymentIntent: Stripe.PaymentIntent) {
   console.log(
@@ -2361,12 +2397,32 @@ export async function handlePaymentIntentCanceled(paymentIntent: Stripe.PaymentI
       paymentIntent.cancellation_reason || 'unspecified'
     }`,
   );
-  // The actual reservation release happens in
-  // `app/api/cron/cleanup-expired-reservations` based on `expiresAt` and
-  // in `handleChargeRefunded` for refund-driven cancellations. This
-  // handler exists so the post-event Novu trigger fires (so we can send
-  // a "booking cancelled" email if appropriate) and so the event no
-  // longer logs as "Unhandled".
+
+  try {
+    const deleted = await db
+      .delete(SlotReservationTable)
+      .where(eq(SlotReservationTable.stripePaymentIntentId, paymentIntent.id))
+      .returning({ id: SlotReservationTable.id });
+
+    if (deleted.length > 0) {
+      console.log(
+        `🗑️ Released slot reservation ${deleted[0].id} for canceled PI ${paymentIntent.id}`,
+      );
+    } else {
+      // No matching reservation — the slot was already freed (e.g., by
+      // a refund flow, the cleanup cron, or because this was a card
+      // payment with no reservation in the first place).
+      console.log(
+        `No slot reservation to release for canceled PI ${paymentIntent.id}`,
+      );
+    }
+  } catch (dbError) {
+    // Same rationale as above — don't fail the webhook.
+    console.error(
+      `Failed to release slot reservation for canceled PI ${paymentIntent.id}:`,
+      dbError,
+    );
+  }
 }
 
 /**

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -49,6 +49,7 @@ import {
   STRIPE_PAYMENT_STATUS_UNPAID,
 } from '@/lib/constants/payment-statuses';
 import { PAYMENT_TRANSFER_STATUS_PENDING } from '@/lib/constants/payment-transfers';
+import { triggerWorkflow } from '@/lib/integrations/novu';
 import { sendEmail } from '@/lib/integrations/novu/email';
 import {
   buildNovuSubscriberFromStripe,
@@ -73,7 +74,10 @@ import { handleIdentityVerificationUpdated } from './handlers/identity';
 import {
   handleChargeRefunded,
   handleDisputeCreated,
+  handleDisputeUpdated,
   handlePaymentFailed,
+  handlePaymentIntentCanceled,
+  handlePaymentIntentProcessing,
   handlePaymentIntentRequiresAction,
   handlePaymentSucceeded,
   handleRefundUpdated,
@@ -673,11 +677,6 @@ async function handlePackPurchase(session: StripeCheckoutSession) {
   });
 
   try {
-    const { default: PackPurchaseConfirmationTemplate } = await import(
-      '@/emails/packs/pack-purchase-confirmation'
-    );
-    const { render } = await import('@react-email/render');
-
     const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://eleva.care';
 
     // Look up expert's username for the booking URL
@@ -699,9 +698,23 @@ async function handlePackPurchase(session: StripeCheckoutSession) {
       console.error('Failed to look up expert username for booking URL:', lookupError);
     }
 
-    const renderedHtml = await render(
-      PackPurchaseConfirmationTemplate({
-        buyerName: buyerName || buyerEmail.split('@')[0],
+    // Route the confirmation through the dedicated `pack-purchase-confirmation`
+    // Novu workflow rather than calling Resend `sendEmail` directly. This
+    // preserves the in-app notification, idempotency via `transactionId`,
+    // template selection, and prop adapter contract — same surface every
+    // other email in this app uses.
+    const resolvedBuyerName = buyerName || buyerEmail.split('@')[0];
+    const [firstName, ...lastNameParts] = resolvedBuyerName.split(' ');
+    const packResult = await triggerWorkflow({
+      workflowId: 'pack-purchase-confirmation',
+      to: {
+        subscriberId: `guest_${buyerEmail}`,
+        email: buyerEmail,
+        firstName: firstName || undefined,
+        lastName: lastNameParts.join(' ') || undefined,
+      },
+      payload: {
+        buyerName: resolvedBuyerName,
         buyerEmail,
         packName,
         eventName,
@@ -711,24 +724,16 @@ async function handlePackPurchase(session: StripeCheckoutSession) {
         expiresAt: expiresAt.toISOString(),
         bookingUrl,
         locale,
-      }),
-    );
-
-    const emailResult = await sendEmail({
-      to: buyerEmail,
-      subject:
-        locale === 'pt' || locale === 'pt-BR'
-          ? `Seu pacote de ${sessionsCount} sessões está pronto!`
-          : locale === 'es'
-            ? `¡Tu paquete de ${sessionsCount} sesiones está listo!`
-            : `Your ${sessionsCount}-session pack is ready!`,
-      html: renderedHtml,
+      },
+      transactionId: `pack-purchase-${session.id}`,
     });
 
-    if (emailResult.success) {
-      console.log(`📧 Pack purchase confirmation email sent to ${maskedEmail}`);
+    if (packResult) {
+      console.log(`📧 Pack purchase confirmation triggered via Novu for ${maskedEmail}`);
     } else {
-      console.error(`📧 Failed to send pack purchase email to ${maskedEmail}:`, emailResult.error);
+      console.error(
+        `📧 Failed to trigger pack purchase confirmation via Novu for ${maskedEmail}`,
+      );
     }
   } catch (emailError) {
     console.error('Failed to send pack purchase email:', emailError);
@@ -1671,18 +1676,37 @@ export async function POST(request: NextRequest) {
       case 'payment_intent.requires_action':
         await handlePaymentIntentRequiresAction(event.data.object as Stripe.PaymentIntent);
         break;
+      case 'payment_intent.processing':
+        // Multibanco voucher window closed — Stripe holds funds in a
+        // 4-day buffer before resolving to succeeded / payment_failed.
+        // Surfaces "your payment is processing" to the patient via the
+        // post-event Novu trigger (payment-universal, eventType=pending).
+        await handlePaymentIntentProcessing(event.data.object as Stripe.PaymentIntent);
+        break;
+      case 'payment_intent.canceled':
+        await handlePaymentIntentCanceled(event.data.object as Stripe.PaymentIntent);
+        break;
       case 'charge.refunded':
         await handleChargeRefunded(event.data.object as Stripe.Charge);
         break;
       case 'charge.refund.updated':
+      case 'refund.updated':
         // Refunds aren't always immediate (e.g., bank-account rejections).
-        // This event fires when the refund's status changes after creation —
-        // critical for catching `failed`/`canceled` so the DB doesn't stay
-        // at `refunded` for a charge that ultimately wasn't.
+        // Both event types carry the Refund object payload — handle them
+        // identically. `refund.updated` is the modern equivalent emitted
+        // on Refund objects directly. Critical for catching `failed`
+        // /`canceled` refund states.
         await handleRefundUpdated(event.data.object as Stripe.Refund);
         break;
       case 'charge.dispute.created':
         await handleDisputeCreated(event.data.object as Stripe.Dispute);
+        break;
+      case 'charge.dispute.updated':
+      case 'charge.dispute.closed':
+        // Stripe recommends listening for status changes on top of
+        // `created` so internal state stays in sync as the dispute
+        // moves through `under_review` → won/lost/warning_closed.
+        await handleDisputeUpdated(event.data.object as Stripe.Dispute);
         break;
       case 'payment_intent.created': {
         console.log('Payment intent created:', event.data.object.id);

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -705,34 +705,80 @@ async function handlePackPurchase(session: StripeCheckoutSession) {
     // other email in this app uses.
     const resolvedBuyerName = buyerName || buyerEmail.split('@')[0];
     const [firstName, ...lastNameParts] = resolvedBuyerName.split(' ');
-    const packResult = await triggerWorkflow({
-      workflowId: 'pack-purchase-confirmation',
-      to: {
-        subscriberId: `guest_${buyerEmail}`,
-        email: buyerEmail,
-        firstName: firstName || undefined,
-        lastName: lastNameParts.join(' ') || undefined,
-      },
-      payload: {
-        buyerName: resolvedBuyerName,
-        buyerEmail,
-        packName,
-        eventName,
-        expertName,
-        sessionsCount,
-        promotionCode: promoCode.code,
-        expiresAt: expiresAt.toISOString(),
-        bookingUrl,
-        locale,
-      },
-      transactionId: `pack-purchase-${session.id}`,
-    });
 
-    if (packResult) {
-      console.log(`📧 Pack purchase confirmation triggered via Novu for ${maskedEmail}`);
-    } else {
+    // SubscriberId uses the Stripe session id (or customer id when present)
+    // instead of `guest_${buyerEmail}` to avoid leaking the buyer's email
+    // address into structured logs / Novu's subscriber ledger. The actual
+    // address still travels to Novu via `to.email` so deliverability is
+    // unaffected.
+    const guestSubscriberId = customerId
+      ? `guest_${customerId}`
+      : `guest_${session.id}`;
+
+    // Wrap the trigger in a small retry loop so a transient Novu failure
+    // doesn't silently lose the confirmation. The trigger is idempotent
+    // via `transactionId: pack-purchase-${session.id}`, so retrying is
+    // safe — Novu dedupes by transactionId. We deliberately do NOT throw
+    // out of the catch / return a non-2xx status: the pack-purchase row
+    // was already inserted above (no idempotency key on the insert), so
+    // a Stripe webhook retry would re-run `handlePackPurchase` and hit
+    // the `stripeSessionId` unique constraint. Better to ack the webhook
+    // and surface the failure via logs / monitoring.
+    const PACK_NOTIFY_MAX_ATTEMPTS = 3;
+    let packResult: unknown = null;
+    let lastError: unknown = null;
+
+    for (let attempt = 1; attempt <= PACK_NOTIFY_MAX_ATTEMPTS; attempt++) {
+      try {
+        packResult = await triggerWorkflow({
+          workflowId: 'pack-purchase-confirmation',
+          to: {
+            subscriberId: guestSubscriberId,
+            email: buyerEmail,
+            firstName: firstName || undefined,
+            lastName: lastNameParts.join(' ') || undefined,
+          },
+          payload: {
+            buyerName: resolvedBuyerName,
+            buyerEmail,
+            packName,
+            eventName,
+            expertName,
+            sessionsCount,
+            promotionCode: promoCode.code,
+            expiresAt: expiresAt.toISOString(),
+            bookingUrl,
+            locale,
+          },
+          transactionId: `pack-purchase-${session.id}`,
+        });
+
+        if (packResult) {
+          if (attempt > 1) {
+            console.log(
+              `📧 Pack purchase confirmation triggered via Novu for ${maskedEmail} on attempt ${attempt}`,
+            );
+          } else {
+            console.log(`📧 Pack purchase confirmation triggered via Novu for ${maskedEmail}`);
+          }
+          break;
+        }
+      } catch (attemptError) {
+        lastError = attemptError;
+      }
+
+      // Exponential backoff between attempts: 250ms, 500ms.
+      if (attempt < PACK_NOTIFY_MAX_ATTEMPTS) {
+        const backoffMs = 250 * 2 ** (attempt - 1);
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+      }
+    }
+
+    if (!packResult) {
       console.error(
-        `📧 Failed to trigger pack purchase confirmation via Novu for ${maskedEmail}`,
+        `📧 Failed to trigger pack purchase confirmation via Novu for ${maskedEmail} ` +
+          `after ${PACK_NOTIFY_MAX_ATTEMPTS} attempts (sessionId=${session.id})`,
+        lastError,
       );
     }
   } catch (emailError) {

--- a/config/novu-workflows.ts
+++ b/config/novu-workflows.ts
@@ -9,6 +9,21 @@
  * await triggerWorkflow({ workflowId: WORKFLOW_IDS.PAYOUT_NOTIFICATION, ... });
  */
 
+/**
+ * Every entry MUST correspond to a `workflow(...)` definition in
+ * `config/novu.ts`. Adding an ID here without a matching workflow
+ * implementation is a no-op trigger at runtime — `triggerWorkflow` will
+ * succeed but nothing fires.
+ *
+ * Removed in 2026-04 audit (no workflow implementation, no callers):
+ *   - USER_LOGIN_NOTIFICATION ('user-login-notification')
+ *   - PAYMENT_SUCCESS ('payment-success') — payments go through PAYMENT_UNIVERSAL
+ *   - PAYMENT_FAILED ('payment-failed')   — same as above
+ *   - APPOINTMENT_REMINDER_24HR ('appointment-reminder-24hr')
+ *     — reminders go through APPOINTMENT_UNIVERSAL with eventType 'reminder'
+ *   - EXPERT_ACCOUNT_UPDATED ('expert-account-updated')
+ *     — expert account events go through EXPERT_MANAGEMENT with notificationType 'account-update'
+ */
 export const WORKFLOW_IDS = {
   // User & Authentication
   // NOTE: user-lifecycle handles welcome emails with idempotency via welcomeEmailSentAt field
@@ -18,26 +33,27 @@ export const WORKFLOW_IDS = {
 
   // DEPRECATED: Use USER_LIFECYCLE instead - kept for backwards compatibility
   USER_WELCOME: 'user-lifecycle', // Maps to USER_LIFECYCLE (same workflow ID)
-  USER_LOGIN_NOTIFICATION: 'user-login-notification',
 
   // Payments & Payouts
   PAYMENT_UNIVERSAL: 'payment-universal',
-  PAYMENT_SUCCESS: 'payment-success',
-  PAYMENT_FAILED: 'payment-failed',
   EXPERT_PAYOUT_NOTIFICATION: 'expert-payout-notification',
 
   // Appointments
   APPOINTMENT_UNIVERSAL: 'appointment-universal',
   APPOINTMENT_CONFIRMATION: 'appointment-confirmation',
-  APPOINTMENT_REMINDER_24HR: 'appointment-reminder-24hr',
 
   // Multibanco Payments
   MULTIBANCO_BOOKING_PENDING: 'multibanco-booking-pending',
   MULTIBANCO_PAYMENT_REMINDER: 'multibanco-payment-reminder',
 
+  // Pack Purchases
+  PACK_PURCHASE_CONFIRMATION: 'pack-purchase-confirmation',
+
+  // Reservations
+  RESERVATION_EXPIRED: 'reservation-expired',
+
   // Expert Management
   EXPERT_MANAGEMENT: 'expert-management',
-  EXPERT_ACCOUNT_UPDATED: 'expert-account-updated',
 
   // Marketplace
   MARKETPLACE_UNIVERSAL: 'marketplace-universal',
@@ -62,8 +78,19 @@ export const WORKFLOW_ID_MAPPINGS = {
   // Old ID -> New standardized ID
   'health-check-failure': WORKFLOW_IDS.SYSTEM_HEALTH,
   'appointment-reminder': WORKFLOW_IDS.APPOINTMENT_UNIVERSAL,
+  'appointment-reminder-24hr': WORKFLOW_IDS.APPOINTMENT_UNIVERSAL,
   'user-created': WORKFLOW_IDS.USER_LIFECYCLE,
-  'recent-login-v2': WORKFLOW_IDS.USER_LOGIN_NOTIFICATION,
+  // Recent-login notifications now ride on `security-auth` (with
+  // eventType: 'recent-login') rather than a dedicated workflow.
+  'recent-login-v2': WORKFLOW_IDS.SECURITY_AUTH,
+  'user-login-notification': WORKFLOW_IDS.SECURITY_AUTH,
+  // Expert account updates now ride on `expert-management` with
+  // notificationType: 'account-update'.
+  'expert-account-updated': WORKFLOW_IDS.EXPERT_MANAGEMENT,
+  // Payment success/failure events now ride on the universal payment
+  // workflow with eventType: 'success' / 'failed'.
+  'payment-success': WORKFLOW_IDS.PAYMENT_UNIVERSAL,
+  'payment-failed': WORKFLOW_IDS.PAYMENT_UNIVERSAL,
   'user-welcome': WORKFLOW_IDS.USER_LIFECYCLE, // DEPRECATED: Maps to user-lifecycle
 } as const;
 
@@ -104,26 +131,17 @@ export const WORKFLOW_CATEGORIES = {
   AUTH: [
     WORKFLOW_IDS.USER_LIFECYCLE, // Handles welcome emails (idempotent)
     WORKFLOW_IDS.SECURITY_AUTH,
-    WORKFLOW_IDS.USER_LOGIN_NOTIFICATION,
     // USER_WELCOME is deprecated - use USER_LIFECYCLE
   ],
   PAYMENTS: [
     WORKFLOW_IDS.PAYMENT_UNIVERSAL,
-    WORKFLOW_IDS.PAYMENT_SUCCESS,
-    WORKFLOW_IDS.PAYMENT_FAILED,
     WORKFLOW_IDS.EXPERT_PAYOUT_NOTIFICATION,
     WORKFLOW_IDS.MULTIBANCO_BOOKING_PENDING,
     WORKFLOW_IDS.MULTIBANCO_PAYMENT_REMINDER,
+    WORKFLOW_IDS.PACK_PURCHASE_CONFIRMATION,
+    WORKFLOW_IDS.RESERVATION_EXPIRED,
   ],
-  APPOINTMENTS: [
-    WORKFLOW_IDS.APPOINTMENT_UNIVERSAL,
-    WORKFLOW_IDS.APPOINTMENT_CONFIRMATION,
-    WORKFLOW_IDS.APPOINTMENT_REMINDER_24HR,
-  ],
-  EXPERTS: [
-    WORKFLOW_IDS.EXPERT_MANAGEMENT,
-    WORKFLOW_IDS.MARKETPLACE_UNIVERSAL,
-    WORKFLOW_IDS.EXPERT_ACCOUNT_UPDATED,
-  ],
+  APPOINTMENTS: [WORKFLOW_IDS.APPOINTMENT_UNIVERSAL, WORKFLOW_IDS.APPOINTMENT_CONFIRMATION],
+  EXPERTS: [WORKFLOW_IDS.EXPERT_MANAGEMENT, WORKFLOW_IDS.MARKETPLACE_UNIVERSAL],
   SYSTEM: [WORKFLOW_IDS.SYSTEM_HEALTH],
 } as const;

--- a/config/novu.ts
+++ b/config/novu.ts
@@ -36,6 +36,24 @@ export const userLifecycleWorkflow = workflow(
     });
 
     await step.email('welcome-email', async () => {
+      // Defensive guard: only the actual onboarding events should render
+      // the welcome email body. Any other `eventType` reaching this
+      // workflow is a routing bug — a real "account-updated" or payment
+      // event must go through `expert-management` (or another dedicated
+      // workflow), never here. We deliberately render an empty body and
+      // log instead of shipping a misleading "Welcome to Eleva Care!"
+      // for arbitrary triggers (the original bug this guard prevents).
+      const eventType = payload.eventType ?? 'welcome';
+      if (eventType !== 'welcome' && eventType !== 'user-created') {
+        console.warn(
+          `[user-lifecycle] Skipping welcome email for unsupported eventType "${eventType}". Route this notification through a dedicated workflow (e.g. expert-management).`,
+        );
+        return {
+          subject: `Eleva Care notification`,
+          body: '<p>(no email body for this event type)</p>',
+        };
+      }
+
       const emailBody = await elevaEmailService.renderWelcomeEmail({
         userName: payload.userName || payload.firstName || 'User',
         firstName: payload.firstName || payload.userName || 'User',
@@ -660,15 +678,32 @@ export const marketplaceWorkflow = workflow(
       },
     }));
 
-    await step.email('marketplace-email', async () => ({
-      subject: `💰 Marketplace Update - Eleva Care`,
-      body: `
-<h2>Marketplace Update</h2>
-<p>Hi ${payload.expertName || 'there'},</p>
-<p>${payload.message || 'Your marketplace account has been updated.'}</p>
-<p>Thank you for being part of our marketplace!</p>
-      `,
-    }));
+    await step.email('marketplace-email', async () => {
+      // Branded React Email template (replaces the prior inline HTML body
+      // that shipped unbranded). Subject reflects the event type so the
+      // expert's inbox shows e.g. "💰 Payment received - Eleva Care"
+      // instead of a generic "Marketplace Update".
+      const emailBody = await elevaEmailService.renderMarketplaceEvent({
+        expertName: payload.expertName,
+        message: payload.message,
+        amount: payload.amount,
+        accountStatus: payload.accountStatus,
+        eventType: payload.eventType,
+        locale: payload.locale,
+      });
+
+      const heading =
+        payload.eventType === 'payout-processed'
+          ? 'Payout processed'
+          : payload.eventType === 'connect-account-status'
+            ? 'Account update'
+            : 'Payment received';
+
+      return {
+        subject: `💰 ${heading} - Eleva Care`,
+        body: emailBody,
+      };
+    });
   },
   {
     name: 'Marketplace Updates',
@@ -708,17 +743,22 @@ export const systemHealthWorkflow = workflow(
       },
     }));
 
-    await step.email('health-email', async () => ({
-      subject: `⚠️ System Health Alert - ${payload.environment}`,
-      body: `
-<h2>System Health Alert</h2>
-<p>Status: ${payload.status}</p>
-<p>Environment: ${payload.environment}</p>
-<p>Error: ${payload.error || 'Unknown error'}</p>
-<p>Timestamp: ${payload.timestamp}</p>
-<p>Please investigate immediately.</p>
-      `,
-    }));
+    await step.email('health-email', async () => {
+      // Branded React Email template (replaces the prior inline HTML body).
+      const emailBody = await elevaEmailService.renderSystemHealthAlert({
+        status: payload.status,
+        environment: payload.environment,
+        error: payload.error,
+        timestamp: payload.timestamp,
+        memory: payload.memory,
+        locale: payload.locale,
+      });
+
+      return {
+        subject: `${payload.status === 'unhealthy' ? '⚠️' : '✅'} System Health: ${payload.status} (${payload.environment})`,
+        body: emailBody,
+      };
+    });
   },
   {
     name: 'System Health',
@@ -748,7 +788,25 @@ export const systemHealthWorkflow = workflow(
   },
 );
 
-// EXISTING EMAIL TEMPLATE WORKFLOWS (Keep these working as they are)
+// `appointment-confirmation` is intentionally kept as a separate workflow
+// from `appointment-universal.confirmed` even though both render the same
+// `ExpertNewAppointmentTemplate`. The two paths exist because:
+//
+//   1. `appointment-universal.confirmed` is the generic Stripe-driven path
+//      (called from `triggerNovuNotificationFromStripeEvent` after a
+//      checkout.session.completed event for the patient side).
+//   2. `appointment-confirmation` is the meeting-actions path called from
+//      `server/actions/meetings.ts` (`triggerExpertAppointmentConfirmation`)
+//      for cases where the booking didn't originate from a Stripe Checkout
+//      Session — e.g. pack-redemption bookings, admin-created meetings,
+//      or any future flow that creates a meeting without a payment intent.
+//      That path needs a workflow it can trigger directly with a flat
+//      payload, without having to fake a Stripe event.
+//
+// Consolidating them would force every non-Stripe meeting creation to also
+// trigger a fake `appointment-universal.confirmed` payload — more friction
+// for marginal cleanliness gains. Keep both, but keep their adapter rows
+// in sync (see lib/integrations/novu/email-service.ts).
 export const appointmentConfirmationWorkflow = workflow(
   'appointment-confirmation',
   async ({ payload, step }) => {
@@ -1165,6 +1223,83 @@ export const reservationExpiredWorkflow = workflow(
   },
 );
 
+// Pack Purchase Confirmation Workflow — sent to the buyer after a session
+// pack is purchased through Stripe Checkout. Carries the redemption promo
+// code that unlocks `sessionsCount` future bookings with the expert. Was
+// previously sent via Resend `sendEmail` directly from the webhook handler,
+// bypassing Novu (no in-app notification, no idempotency, no template
+// selection). Now goes through this workflow like every other email.
+export const packPurchaseConfirmationWorkflow = workflow(
+  'pack-purchase-confirmation',
+  async ({ payload, step }) => {
+    await step.inApp('pack-purchase-inapp', async () => ({
+      subject: `🎉 Your ${payload.sessionsCount}-session pack with ${payload.expertName} is ready`,
+      body: `Your booking code is ${payload.promotionCode}. Redeem it at the expert's booking page when you're ready to book each session.`,
+      data: {
+        packName: payload.packName,
+        eventName: payload.eventName,
+        expertName: payload.expertName,
+        sessionsCount: payload.sessionsCount,
+        promotionCode: payload.promotionCode,
+        bookingUrl: payload.bookingUrl,
+        expiresAt: payload.expiresAt,
+      },
+    }));
+
+    await step.email('pack-purchase-email', async () => {
+      const emailBody = await elevaEmailService.renderPackPurchase({
+        buyerName: payload.buyerName,
+        buyerEmail: payload.buyerEmail,
+        packName: payload.packName,
+        eventName: payload.eventName,
+        expertName: payload.expertName,
+        sessionsCount: payload.sessionsCount,
+        promotionCode: payload.promotionCode,
+        expiresAt: payload.expiresAt,
+        bookingUrl: payload.bookingUrl,
+        locale: payload.locale || 'en',
+      });
+
+      // Match the locale-aware subject we used to build inline in the
+      // webhook handler so existing inboxes show consistent copy.
+      const baseLocale = (payload.locale || 'en').split('-')[0].toLowerCase();
+      const subject =
+        baseLocale === 'pt'
+          ? `Seu pacote de ${payload.sessionsCount} sessões está pronto!`
+          : baseLocale === 'es'
+            ? `¡Tu paquete de ${payload.sessionsCount} sesiones está listo!`
+            : `Your ${payload.sessionsCount}-session pack is ready!`;
+
+      return { subject, body: emailBody };
+    });
+  },
+  {
+    name: 'Pack Purchase Confirmation',
+    description:
+      'Notifies the buyer that their session pack is ready and delivers the redemption promo code.',
+    payloadSchema: z.object({
+      buyerName: z.string(),
+      buyerEmail: z.string().email(),
+      packName: z.string(),
+      eventName: z.string(),
+      expertName: z.string(),
+      sessionsCount: z.number().int().positive(),
+      promotionCode: z.string(),
+      expiresAt: z.string(),
+      bookingUrl: z.string(),
+      locale: z.string().optional().default('en'),
+    }),
+    tags: ['payments', 'packs', 'confirmation'],
+    preferences: {
+      all: { enabled: true },
+      channels: {
+        email: { enabled: true },
+        inApp: { enabled: true },
+      },
+    },
+  },
+);
+
 // All workflows exported for the Novu framework
 export const workflows = [
   userLifecycleWorkflow,
@@ -1179,6 +1314,7 @@ export const workflows = [
   multibancoPaymentReminderWorkflow,
   expertPayoutNotificationWorkflow,
   reservationExpiredWorkflow,
+  packPurchaseConfirmationWorkflow,
 ];
 
 // Add to the existing workflow configuration

--- a/config/novu.ts
+++ b/config/novu.ts
@@ -319,6 +319,39 @@ export const paymentWorkflow = workflow(
             : locale === 'es'
               ? `❌ Pago fallido - ${payload.currency || 'EUR'} ${payload.amount}`
               : `❌ Payment Failed - ${payload.currency || 'EUR'} ${payload.amount}`;
+      } else if (payload.eventType === 'pending') {
+        // `pending` fires when a Multibanco voucher's 7-day payment window
+        // closed and Stripe is now confirming the funds in its 4-day
+        // settlement buffer (see `handlePaymentIntentProcessing` in
+        // `app/api/webhooks/stripe/handlers/payment.ts`). The patient has
+        // already paid — they just need to know we're processing. The
+        // in-app notification (above) already conveys this; the email is
+        // a minimal "we're confirming your payment" message rather than
+        // the generic HTML fallback that would otherwise render here.
+        const locale = (payload.locale || 'en').toLowerCase().split('-')[0];
+        const customerLine =
+          locale === 'pt'
+            ? `Olá ${payload.customerName || ''},`
+            : locale === 'es'
+              ? `Hola ${payload.customerName || ''},`
+              : `Hello ${payload.customerName || ''},`;
+        const bodyLine =
+          locale === 'pt'
+            ? 'Recebemos a confirmação do seu pagamento Multibanco. Estamos a aguardar a transferência dos fundos do seu banco — esta é uma fase normal e o seu agendamento permanece reservado. Iremos enviar a confirmação final assim que os fundos chegarem (normalmente até 4 dias úteis).'
+            : locale === 'es'
+              ? 'Hemos recibido la confirmación de su pago Multibanco. Estamos esperando que los fondos lleguen desde su banco — esta es una fase normal y su reserva sigue activa. Le enviaremos la confirmación final en cuanto lleguen los fondos (normalmente en un plazo de 4 días hábiles).'
+              : "We've received your Multibanco payment confirmation. We're now waiting for the funds to clear from your bank — this is a normal step and your booking remains reserved. We'll send the final confirmation as soon as the funds arrive (usually within 4 business days).";
+        emailBody = `<div style="font-family: system-ui, sans-serif; line-height: 1.6; color: #1F2937;">
+  <p>${customerLine}</p>
+  <p>${bodyLine}</p>
+  <p style="color: #6B7280; font-size: 14px;">— Eleva Care</p>
+</div>`;
+        subject =
+          locale === 'pt'
+            ? '⏳ A processar o seu pagamento Multibanco'
+            : locale === 'es'
+              ? '⏳ Procesando su pago Multibanco'
+              : '⏳ Processing your Multibanco payment';
       } else {
         // Use generic email renderer for other payment events
         emailBody = await elevaEmailService.renderGenericEmail({
@@ -692,15 +725,20 @@ export const marketplaceWorkflow = workflow(
         locale: payload.locale,
       });
 
+      // Subject heading + emoji are picked per-event so the inbox preview
+      // is informative without opening the email. Keep this in sync with
+      // `MarketplaceEventType` in `emails/experts/marketplace-event.tsx`.
       const heading =
         payload.eventType === 'payout-processed'
-          ? 'Payout processed'
+          ? '🏦 Payout processed'
           : payload.eventType === 'connect-account-status'
-            ? 'Account update'
-            : 'Payment received';
+            ? '🔧 Account update'
+            : payload.eventType === 'refund-processed'
+              ? '↩️ Refund processed'
+              : '💰 Payment received';
 
       return {
-        subject: `💰 ${heading} - Eleva Care`,
+        subject: `${heading} - Eleva Care`,
         body: emailBody,
       };
     });
@@ -709,7 +747,16 @@ export const marketplaceWorkflow = workflow(
     name: 'Marketplace Updates',
     description: 'Notifications for marketplace account and payment status changes',
     payloadSchema: z.object({
-      eventType: z.enum(['payment-received', 'payout-processed', 'connect-account-status']),
+      // `refund-processed` is fired by `notifyAppointmentConflict` in
+      // `app/api/webhooks/stripe/handlers/payment.ts` after a double-booking
+      // refund completes. Keep this enum in sync with `MarketplaceEventType`
+      // in `emails/experts/marketplace-event.tsx`.
+      eventType: z.enum([
+        'payment-received',
+        'payout-processed',
+        'connect-account-status',
+        'refund-processed',
+      ]),
       amount: z.string().optional(),
       expertName: z.string().optional(),
       accountStatus: z.string().optional(),

--- a/docs/02-core-systems/notifications/09-email-system-audit-2026-04.md
+++ b/docs/02-core-systems/notifications/09-email-system-audit-2026-04.md
@@ -193,8 +193,10 @@ the connected account, not the platform) or duplicate work.
 
 ### 4.2 `/api/webhooks/stripe` — main platform endpoint (22 events) ✅
 
-Switch handler: [`app/api/webhooks/stripe/route.ts`](../../../app/api/webhooks/stripe/route.ts)
-L1551-1697; post-event Novu trigger: `triggerNovuNotificationFromStripeEvent`.
+Routing happens in the top-level `POST` handler's `event.type` switch in
+[`app/api/webhooks/stripe/route.ts`](../../../app/api/webhooks/stripe/route.ts);
+the post-event Novu trigger is `triggerNovuNotificationFromStripeEvent`
+in the same file.
 
 Subscribed and code-handled (all ✅):
 
@@ -232,8 +234,9 @@ identity.verification_session.{created,processing,requires_input,verified}
 
 ### 4.4 `/api/webhooks/stripe-connect` — Connected-accounts endpoint (15 events) ✅
 
-Switch handler: [`app/api/webhooks/stripe-connect/route.ts`](../../../app/api/webhooks/stripe-connect/route.ts)
-L90-280. **Critical — events on this endpoint scope to "Connected and v2
+Routing happens in the top-level `POST` handler's `event.type` switch in
+[`app/api/webhooks/stripe-connect/route.ts`](../../../app/api/webhooks/stripe-connect/route.ts).
+**Critical — events on this endpoint scope to "Connected and v2
 accounts", not "Your account".** Connect-side refunds (initiated from the
 expert's Express dashboard or the Connect view of your Dashboard) fire here
 and would be missed entirely if subscribed only on the main endpoint.
@@ -264,9 +267,9 @@ If you suspect coverage drift later, walk through this once:
 1. Open each of the three endpoints in the Stripe Dashboard.
 2. For each, expand "Listen to events" and capture the subscribed list.
 3. Diff against the code-handled events:
-   - Main: switch in [`app/api/webhooks/stripe/route.ts`](../../../app/api/webhooks/stripe/route.ts) L1551-1697.
-   - Identity: prefix match in [`app/api/webhooks/stripe-identity/route.ts`](../../../app/api/webhooks/stripe-identity/route.ts).
-   - Connect: switch in [`app/api/webhooks/stripe-connect/route.ts`](../../../app/api/webhooks/stripe-connect/route.ts) L90-280.
+   - Main: the `event.type` switch inside the `POST` handler in [`app/api/webhooks/stripe/route.ts`](../../../app/api/webhooks/stripe/route.ts).
+   - Identity: the `event.type.startsWith('identity.verification_session')` prefix match in [`app/api/webhooks/stripe-identity/route.ts`](../../../app/api/webhooks/stripe-identity/route.ts) → `handleVerificationSessionEvent`.
+   - Connect: the `event.type` switch inside the `POST` handler in [`app/api/webhooks/stripe-connect/route.ts`](../../../app/api/webhooks/stripe-connect/route.ts).
 4. For any handler missing a subscription, add it in the Dashboard.
    For any subscription with no handler, decide: add a case, or unsubscribe.
 5. Cross-check `STRIPE_EVENT_TO_WORKFLOW_MAPPINGS` in

--- a/docs/02-core-systems/notifications/09-email-system-audit-2026-04.md
+++ b/docs/02-core-systems/notifications/09-email-system-audit-2026-04.md
@@ -1,0 +1,309 @@
+# Email & Novu System Audit — April 2026
+
+> **Scope.** End-to-end audit of the email + Novu notification system: every
+> template under `emails/`, every workflow in `config/novu.ts`, every
+> `triggerWorkflow` callsite across `app/api/webhooks/`, `app/api/cron/`,
+> `app/api/create-payment-intent/`, `app/api/create-pack-checkout/`,
+> `server/`, and the Stripe-event-to-workflow map.
+>
+> **Audit date.** 2026-04-20 · **Stripe account.** `acct_1QIytSK5Ap4Um3Sp` (Eleva Care)
+>
+> **Status.** All findings resolved (2026-04-20). All three Stripe webhook
+> endpoints (`/stripe`, `/stripe-identity`, `/stripe-connect`) verified
+> subscribed to every code-handled event; `invoice.paid` ↔
+> `invoice.payment_succeeded` mapping mismatch resolved by aligning the code
+> map to Stripe's modern `invoice.paid` event.
+
+---
+
+## 1. Findings table
+
+| # | Severity | Area | Finding | Status |
+|---|---|---|---|---|
+| 1 | **P0 critical** | Notifications core | Expert payment-failure / refund / account-update emails routed through `user-lifecycle` workflow → shipped a "Welcome to Eleva Care!" body | **Fixed** ([`lib/notifications/core.ts`](../../../lib/notifications/core.ts)) — re-routed to `expert-management.account-update`; added defensive guard in `userLifecycleWorkflow.step.email` |
+| 2 | **P1 high** | Pack purchase | Pack confirmation email bypassed Novu entirely — direct Resend `sendEmail` from the webhook | **Fixed** — new `pack-purchase-confirmation` workflow, `renderPackPurchase` method, `propAdapter` row, and regression test |
+| 3 | **P1 high** | Stripe webhook coverage | `payment_intent.processing`, `payment_intent.canceled`, `charge.dispute.updated`, `charge.dispute.closed`, `refund.updated` not handled | **Fixed** — new handlers in [`payment.ts`](../../../app/api/webhooks/stripe/handlers/payment.ts) + switch cases in [`route.ts`](../../../app/api/webhooks/stripe/route.ts); `STRIPE_EVENT_TO_WORKFLOW_MAPPINGS` and `STRIPE_TO_PAYMENT_EVENT_TYPE` updated |
+| 4 | **P1 high** | Stripe Dashboard | Subscribed-events list on the production webhook endpoints must match the switches in the three webhook routes | **Fixed (2026-04-20)** — three endpoints (`/stripe`, `/stripe-identity`, `/stripe-connect`) verified subscribed to all code-handled events; see Section 4 |
+| 5 | **P2 medium** | propAdapter gaps | Several `(workflow, eventType, userSegment)` triples in `templateMappings` had no adapter row → silent passThrough | **Fixed** — explicit adapter rows for `appointment-universal.cancelled` / `default`, `payment-universal.pending`, `appointment-confirmation.default` (patient + expert), `multibanco-booking-pending`, `reservation-expired`, `user-lifecycle.welcome`, plus 6 new tests |
+| 6 | **P2 medium** | Templates | Multibanco entity / reference / amount / expires + service / expert rows rendered unconditionally | **Fixed** — wrapped in truthy guards in [`multibanco-booking-pending.tsx`](../../../emails/payments/multibanco-booking-pending.tsx) and [`multibanco-payment-reminder.tsx`](../../../emails/payments/multibanco-payment-reminder.tsx) |
+| 7 | **P2 medium** | Templates | `appointment-reminder.tsx` heading / banner / preview / subject interpolated `appointmentType` without a guard | **Fixed** — `safeAppointmentType` derived value used everywhere |
+| 8 | **P2 medium** | Templates | `pack-purchase-confirmation.tsx` `previewText` always appended `promotionCode`; promo block always rendered even when empty | **Fixed** — both gated on `promotionCode` truthy |
+| 9 | **P2 medium** | Locale | Reminder caller collapsed `es` / `br` → `'en'` (es/br patients got English reminders) | **Fixed** — added full `es` and `br` translations; widened `AppointmentReminderLocale` to mirror `SupportedLocale`; caller passes normalized locale through |
+| 10 | **P3 low** | Workflow registry | `config/novu-workflows.ts` advertised 5 IDs (`user-login-notification`, `payment-success`, `payment-failed`, `appointment-reminder-24hr`, `expert-account-updated`) with no workflow implementation | **Fixed** — removed dead constants, added them to `WORKFLOW_ID_MAPPINGS` so legacy callers route to the correct unified workflow; added `PACK_PURCHASE_CONFIRMATION` and `RESERVATION_EXPIRED` |
+| 11 | **P3 low** | Inline-HTML emails | `marketplace-universal` and `system-health` shipped inline HTML strings — no branding, no localization | **Fixed** — new [`emails/experts/marketplace-event.tsx`](../../../emails/experts/marketplace-event.tsx) and [`emails/system/system-health-alert.tsx`](../../../emails/system/system-health-alert.tsx); workflows render through `elevaEmailService` like every other email |
+| 12 | **P3 low** | Dead code | `email-service.ts` exported a second `triggerNovuWorkflow` shadowed by `utils.ts`, zero callers | **Fixed** — duplicate removed; replaced with a redirect comment pointing to the canonical version |
+| 13 | **P3 low** | Workflow naming | `appointment-confirmation` is a near-duplicate of `appointment-universal.confirmed` | **Documented** — both kept on purpose: the meeting-actions path needs a workflow it can trigger directly without faking a Stripe event (see header comment in `config/novu.ts`) |
+
+---
+
+## 2. Architecture (post-audit)
+
+```mermaid
+flowchart LR
+  subgraph triggers [Trigger surfaces]
+    StripeWebhook[Stripe webhook]
+    ClerkWebhook[Clerk webhook]
+    Cron[QStash crons]
+    PaymentIntentRoute[create-payment-intent]
+    PackCheckoutRoute[create-pack-checkout]
+    Calendar[googleCalendar.ts]
+    Meetings[meetings.ts action]
+    Healthcheck[healthcheck route]
+    WebhookMonitor[redis webhook-monitor]
+  end
+
+  subgraph wrappers [Wrappers]
+    triggerWorkflow["triggerWorkflow (utils.ts)"]
+    triggerNovuWorkflow["triggerNovuWorkflow (utils.ts)"]
+  end
+
+  subgraph novu [Novu workflows]
+    PaymentUniversal[payment-universal]
+    AppointmentUniversal[appointment-universal]
+    AppointmentConfirmation[appointment-confirmation]
+    UserLifecycle[user-lifecycle]
+    SecurityAuth[security-auth]
+    ExpertManagement[expert-management]
+    ExpertPayout[expert-payout-notification]
+    MultibancoPending[multibanco-booking-pending]
+    MultibancoReminder[multibanco-payment-reminder]
+    ReservationExpired[reservation-expired]
+    Marketplace[marketplace-universal]
+    SystemHealth[system-health]
+    PackPurchase[pack-purchase-confirmation]
+  end
+
+  subgraph email [ElevaEmailService render methods]
+    renderPaymentConfirmation
+    renderAppointmentConfirmation
+    renderAppointmentReminder
+    renderExpertNewAppointment
+    renderMultibancoBookingPending
+    renderMultibancoPaymentReminder
+    renderExpertPayoutNotification
+    renderRefundNotification
+    renderExpertNotification
+    renderReservationExpired
+    renderWelcomeEmail
+    renderPackPurchase
+    renderMarketplaceEvent
+    renderSystemHealthAlert
+  end
+
+  StripeWebhook --> triggerWorkflow
+  StripeWebhook --> triggerNovuWorkflow
+  ClerkWebhook --> triggerNovuWorkflow
+  Cron --> triggerWorkflow
+  Calendar --> triggerWorkflow
+  Meetings --> triggerWorkflow
+  Healthcheck --> triggerWorkflow
+  WebhookMonitor --> triggerWorkflow
+  PackCheckoutRoute -.->|"sets metadata"| StripeWebhook
+  PaymentIntentRoute -.->|"sets metadata"| StripeWebhook
+  StripeWebhook -->|"pack_purchase metadata"| triggerWorkflow
+
+  triggerWorkflow --> PaymentUniversal
+  triggerWorkflow --> AppointmentUniversal
+  triggerWorkflow --> ExpertManagement
+  triggerWorkflow --> SecurityAuth
+  triggerWorkflow --> ExpertPayout
+  triggerWorkflow --> MultibancoPending
+  triggerWorkflow --> MultibancoReminder
+  triggerWorkflow --> ReservationExpired
+  triggerWorkflow --> Marketplace
+  triggerWorkflow --> SystemHealth
+  triggerWorkflow --> PackPurchase
+  triggerNovuWorkflow --> PaymentUniversal
+  triggerNovuWorkflow --> ExpertManagement
+  triggerNovuWorkflow --> UserLifecycle
+  triggerNovuWorkflow --> SecurityAuth
+  Meetings --> AppointmentConfirmation
+
+  PaymentUniversal --> renderPaymentConfirmation
+  PaymentUniversal --> renderMultibancoPaymentReminder
+  PaymentUniversal --> renderRefundNotification
+  AppointmentUniversal --> renderAppointmentConfirmation
+  AppointmentUniversal --> renderAppointmentReminder
+  AppointmentUniversal --> renderExpertNewAppointment
+  AppointmentConfirmation --> renderExpertNewAppointment
+  UserLifecycle --> renderWelcomeEmail
+  SecurityAuth --> renderExpertNotification
+  ExpertPayout --> renderExpertPayoutNotification
+  ExpertManagement --> renderExpertPayoutNotification
+  ExpertManagement --> renderExpertNotification
+  MultibancoPending --> renderMultibancoBookingPending
+  MultibancoReminder --> renderMultibancoPaymentReminder
+  ReservationExpired --> renderReservationExpired
+  Marketplace --> renderMarketplaceEvent
+  SystemHealth --> renderSystemHealthAlert
+  PackPurchase --> renderPackPurchase
+```
+
+---
+
+## 3. Stripe event → workflow map (post-audit)
+
+Source: [`lib/integrations/novu/utils.ts`](../../../lib/integrations/novu/utils.ts) `STRIPE_EVENT_TO_WORKFLOW_MAPPINGS` + `STRIPE_TO_PAYMENT_EVENT_TYPE`.
+
+| Stripe event type | Novu workflow | Resolved `eventType` | Notes |
+|---|---|---|---|
+| `payment_intent.payment_failed` | `payment-universal` | `failed` | Patient + expert notification; expert path also creates `MEETING_PAYMENT_FAILED` audit |
+| `payment_intent.processing` | `payment-universal` | `pending` | NEW — Multibanco voucher entered the 4-day buffer window |
+| `payment_intent.canceled` | `payment-universal` | `cancelled` | NEW — patient or cron explicitly cancelled the PI |
+| `charge.refunded` | `payment-universal` | `refunded` | Renders `RefundNotificationTemplate` |
+| `charge.refund.updated` | `payment-universal` | `refunded` | Existing handler — catches failed/canceled refunds |
+| `refund.updated` | `payment-universal` | `refunded` | NEW — modern refund-object event, mirrors `charge.refund.updated` |
+| `charge.dispute.created` | `payment-universal` | `disputed` | Existing handler |
+| `charge.dispute.updated` | `payment-universal` | `disputed` | NEW — fires on status change (`under_review` → `won`/`lost`) |
+| `charge.dispute.closed` | `payment-universal` | `disputed` | NEW — final dispute resolution |
+| `customer.subscription.{created,updated,deleted}` | `payment-universal` | `confirmed` / `cancelled` | Subscription products are not currently used; mappings retained for forward compatibility |
+| `invoice.paid` | `payment-universal` | `success` | UPDATED — modern Stripe event for invoice payment success; matches Dashboard subscription. The legacy `invoice.payment_succeeded` is kept as a fallback in `STRIPE_TO_PAYMENT_EVENT_TYPE` for older webhook configs. |
+| `invoice.payment_failed` | `payment-universal` | `failed` | |
+| `account.updated` | `expert-management` | `account-update` | Connect account capability changes |
+| `capability.updated` | `expert-management` | `account-update` | |
+| `payout.paid` | `expert-payout-notification` | `payout` | Direct handler in `payout.ts` |
+| `payout.failed` | `marketplace-universal` | `payout-failed` | Direct handler in `payout.ts` |
+| `checkout.session.completed` | (handled inline) | n/a | `handleCheckoutSession` routes to `handlePackPurchase` (NEW: triggers `pack-purchase-confirmation`) or to the booking flow |
+| `checkout.session.async_payment_succeeded` / `async_payment_failed` | (handled inline) | n/a | Multibanco / async post-checkout resolution |
+
+---
+
+## 4. Stripe Dashboard verification (resolved 2026-04-20)
+
+> **Why this section exists.** The Stripe MCP server in this workspace
+> exposes neither `WebhookEndpoints.list` nor `Events.list`, so the
+> subscribed-events list on every endpoint had to be confirmed manually
+> in the Dashboard. This section captures the final state after the audit
+> remediation, so future agents can re-verify against a known-good baseline.
+>
+> **Where.** Stripe Dashboard → Webhooks for `acct_1QIytSK5Ap4Um3Sp`.
+
+### 4.1 Three endpoints, one platform
+
+We split webhook traffic across three endpoints by event scope. A single
+endpoint subscribing to events from both the platform AND connected
+accounts would either miss critical events (Connect-side refunds fire on
+the connected account, not the platform) or duplicate work.
+
+| Endpoint | Webhook ID | Event scope | Signing-secret env var |
+|---|---|---|---|
+| `https://eleva.care/api/webhooks/stripe` | `we_1QwZt1K5Ap4Um3SpFntS3oca` | "Your account" (platform) | `STRIPE_WEBHOOK_SECRET` |
+| `https://eleva.care/api/webhooks/stripe-identity` | (Identity-only) | "Your account" — Identity events only | `STRIPE_IDENTITY_WEBHOOK_SECRET` |
+| `https://eleva.care/api/webhooks/stripe-connect` | (Connect-only) | "Connected and v2 accounts" | (separate Connect secret) |
+
+### 4.2 `/api/webhooks/stripe` — main platform endpoint (22 events) ✅
+
+Switch handler: [`app/api/webhooks/stripe/route.ts`](../../../app/api/webhooks/stripe/route.ts)
+L1551-1697; post-event Novu trigger: `triggerNovuNotificationFromStripeEvent`.
+
+Subscribed and code-handled (all ✅):
+
+```text
+account.updated                          capability.updated
+charge.refunded                          charge.dispute.{closed,created,updated}
+checkout.session.completed               checkout.session.async_payment_{succeeded,failed}
+customer.subscription.{created,updated,deleted}
+invoice.{paid,payment_failed}
+payment_intent.{succeeded,payment_failed,requires_action,processing,canceled}
+payout.{paid,failed}                     refund.updated
+```
+
+Notes:
+- `invoice.paid` is the modern Stripe event; the code mapping was updated
+  to match (`STRIPE_EVENT_TO_WORKFLOW_MAPPINGS` in
+  [`lib/integrations/novu/utils.ts`](../../../lib/integrations/novu/utils.ts)
+  now keys on `invoice.paid`; `invoice.payment_succeeded` retained as a
+  fallback).
+- `customer.subscription.*` and `invoice.*` are subscribed for forward
+  compatibility — no subscription product exists today.
+- `charge.refund.updated` is intentionally NOT subscribed here; it lives
+  on the Connect endpoint where Connect-side refunds actually fire. The
+  modern `refund.updated` covers the platform side.
+
+### 4.3 `/api/webhooks/stripe-identity` — Identity-only endpoint (4 events) ✅
+
+Handler: [`app/api/webhooks/stripe-identity/route.ts`](../../../app/api/webhooks/stripe-identity/route.ts)
+uses a prefix match (`event.type.startsWith('identity.verification_session')`)
+so all four subscribed events route through `handleVerificationSessionEvent`.
+
+```text
+identity.verification_session.{created,processing,requires_input,verified}
+```
+
+### 4.4 `/api/webhooks/stripe-connect` — Connected-accounts endpoint (15 events) ✅
+
+Switch handler: [`app/api/webhooks/stripe-connect/route.ts`](../../../app/api/webhooks/stripe-connect/route.ts)
+L90-280. **Critical — events on this endpoint scope to "Connected and v2
+accounts", not "Your account".** Connect-side refunds (initiated from the
+expert's Express dashboard or the Connect view of your Dashboard) fire here
+and would be missed entirely if subscribed only on the main endpoint.
+
+Subscribed and code-handled (✅):
+
+```text
+account.updated                          account.application.deauthorized
+account.external_account.{created,updated,deleted}
+charge.refunded                          charge.refund.updated
+payout.{created,paid,failed}
+```
+
+Subscribed but currently no-op (cosmetic; logged under default branch):
+
+```text
+account.application.authorized           capability.updated
+payout.updated                           person.{created,updated}
+```
+
+These are safe to leave subscribed — useful if we ever add handler
+cases. Unsubscribe to reduce inbound noise if preferred.
+
+### 4.5 Re-verification recipe
+
+If you suspect coverage drift later, walk through this once:
+
+1. Open each of the three endpoints in the Stripe Dashboard.
+2. For each, expand "Listen to events" and capture the subscribed list.
+3. Diff against the code-handled events:
+   - Main: switch in [`app/api/webhooks/stripe/route.ts`](../../../app/api/webhooks/stripe/route.ts) L1551-1697.
+   - Identity: prefix match in [`app/api/webhooks/stripe-identity/route.ts`](../../../app/api/webhooks/stripe-identity/route.ts).
+   - Connect: switch in [`app/api/webhooks/stripe-connect/route.ts`](../../../app/api/webhooks/stripe-connect/route.ts) L90-280.
+4. For any handler missing a subscription, add it in the Dashboard.
+   For any subscription with no handler, decide: add a case, or unsubscribe.
+5. Cross-check `STRIPE_EVENT_TO_WORKFLOW_MAPPINGS` in
+   [`lib/integrations/novu/utils.ts`](../../../lib/integrations/novu/utils.ts)
+   matches the subscribed event names exactly (the `invoice.paid` vs
+   `invoice.payment_succeeded` mismatch was a real-world example — both
+   exist as Stripe events, but they're not interchangeable in maps).
+6. After any subscription change, send a test event from the Dashboard
+   ("Send test webhook") and confirm the endpoint returns HTTP 200 in
+   the delivery log.
+
+---
+
+## 5. Resolution status tracker
+
+| Plan todo | Status | Commit / file(s) |
+|---|---|---|
+| `p0-fix-user-lifecycle-branching` | Done | [`lib/notifications/core.ts`](../../../lib/notifications/core.ts), [`config/novu.ts`](../../../config/novu.ts) |
+| `p1-pack-novu-workflow` | Done | [`config/novu.ts`](../../../config/novu.ts), [`lib/integrations/novu/email-service.ts`](../../../lib/integrations/novu/email-service.ts), [`app/api/webhooks/stripe/route.ts`](../../../app/api/webhooks/stripe/route.ts), [`tests/lib/integrations/novu/email-service.test.ts`](../../../tests/lib/integrations/novu/email-service.test.ts) |
+| `p1-stripe-events` | Done | [`app/api/webhooks/stripe/handlers/payment.ts`](../../../app/api/webhooks/stripe/handlers/payment.ts), [`app/api/webhooks/stripe/route.ts`](../../../app/api/webhooks/stripe/route.ts), [`lib/integrations/novu/utils.ts`](../../../lib/integrations/novu/utils.ts) |
+| `p1-stripe-dashboard-check` | Done (2026-04-20) | Section 4 above — three endpoints (`/stripe`, `/stripe-identity`, `/stripe-connect`) verified subscribed to all code-handled events |
+| `p2-multibanco-rows` | Done | [`emails/payments/multibanco-booking-pending.tsx`](../../../emails/payments/multibanco-booking-pending.tsx), [`emails/payments/multibanco-payment-reminder.tsx`](../../../emails/payments/multibanco-payment-reminder.tsx) |
+| `p2-reminder-appttype` | Done | [`emails/appointments/appointment-reminder.tsx`](../../../emails/appointments/appointment-reminder.tsx) |
+| `p2-pack-promo-preview` | Done | [`emails/packs/pack-purchase-confirmation.tsx`](../../../emails/packs/pack-purchase-confirmation.tsx) |
+| `p2-adapter-gaps` | Done | [`lib/integrations/novu/email-service.ts`](../../../lib/integrations/novu/email-service.ts) (6 new adapter rows + 6 regression tests) |
+| `p2-reminder-translations` | Done | [`emails/appointments/appointment-reminder.tsx`](../../../emails/appointments/appointment-reminder.tsx) (es + br); caller in [`email-service.ts`](../../../lib/integrations/novu/email-service.ts) updated |
+| `p3-workflow-registry` | Done | [`config/novu-workflows.ts`](../../../config/novu-workflows.ts) |
+| `p3-marketplace-template` | Done | [`emails/experts/marketplace-event.tsx`](../../../emails/experts/marketplace-event.tsx), [`emails/system/system-health-alert.tsx`](../../../emails/system/system-health-alert.tsx), [`config/novu.ts`](../../../config/novu.ts), [`lib/integrations/novu/email-service.ts`](../../../lib/integrations/novu/email-service.ts) |
+| `p3-dead-trigger` | Done | [`lib/integrations/novu/email-service.ts`](../../../lib/integrations/novu/email-service.ts) |
+| `p3-appt-confirmation-dedupe` | Documented | Header comment in [`config/novu.ts`](../../../config/novu.ts) above `appointmentConfirmationWorkflow` |
+
+---
+
+## 6. How to keep this audit green
+
+1. **Adapters.** When adding a new workflow, add a matching `propAdapter` row in [`lib/integrations/novu/email-service.ts`](../../../lib/integrations/novu/email-service.ts) (even if it's identity) AND a regression test in [`tests/lib/integrations/novu/email-service.test.ts`](../../../tests/lib/integrations/novu/email-service.test.ts). The default `passThrough` fallback works only when the payload happens to match the template's prop names — which is exactly the silent failure mode the placeholder-leak bug shipped on.
+2. **Templates.** When adding a row to a template, gate it on the truthy value of the prop it depends on. Empty cells / dangling labels look like layout bugs to the recipient.
+3. **Workflow IDs.** Don't add a constant to [`config/novu-workflows.ts`](../../../config/novu-workflows.ts) without a matching `workflow(...)` definition in [`config/novu.ts`](../../../config/novu.ts). Use `WORKFLOW_ID_MAPPINGS` for legacy aliases.
+4. **Stripe events.** When adding a new `case` in [`app/api/webhooks/stripe/route.ts`](../../../app/api/webhooks/stripe/route.ts), add the matching mapping in [`lib/integrations/novu/utils.ts`](../../../lib/integrations/novu/utils.ts) AND subscribe the event in the production webhook endpoint.
+5. **Email body source.** Prefer React Email templates over inline HTML in `step.email` returns. The two remaining inline-HTML escape hatches were replaced in this audit; new ones should follow the same pattern.

--- a/emails/appointments/appointment-reminder.tsx
+++ b/emails/appointments/appointment-reminder.tsx
@@ -68,15 +68,21 @@ export const AppointmentReminderEmail = ({
   meetingLink,
   locale = 'en',
 }: AppointmentReminderEmailProps) => {
-  // Defensive default: callers occasionally forward an empty string when
-  // the upstream `eventName` is missing. Without this guard the inbox
-  // preview would read "...tomorrow - " (trailing dash + nothing) and the
-  // banner / heading would render an empty paragraph. Keep the same neutral
-  // fallback the prop default uses.
+  // Per-locale fallback for the appointment-type label. Callers occasionally
+  // forward an empty string when the upstream `eventName` is missing, so we
+  // need a non-empty value for the banner / heading / inbox-preview
+  // interpolation. Using a localized fallback keeps the email coherent
+  // for non-English recipients (was previously hardcoded "Your appointment").
+  const APPOINTMENT_TYPE_FALLBACK: Record<AppointmentReminderLocale, string> = {
+    en: 'Your appointment',
+    pt: 'A sua consulta',
+    br: 'Sua consulta',
+    es: 'Su cita',
+  };
   const safeAppointmentType =
     typeof appointmentType === 'string' && appointmentType.trim().length > 0
       ? appointmentType
-      : 'Your appointment';
+      : APPOINTMENT_TYPE_FALLBACK[locale];
 
   // Internationalization support
   const translations = {

--- a/emails/appointments/appointment-reminder.tsx
+++ b/emails/appointments/appointment-reminder.tsx
@@ -11,17 +11,16 @@ import type { SupportedLocale } from '@/emails/utils/i18n';
 import { Heading, Hr, Section, Text } from '@react-email/components';
 
 /**
- * Locales for which this template has a translation entry. Narrower than
- * the global `SupportedLocale` (which also includes `'es'` and `'br'`)
- * because the `translations` table below only ships strings for `'en'`
- * and `'pt'`. Tightening the prop type forces callers to choose one of
- * the implemented locales at compile time instead of silently falling
- * back to English at runtime.
+ * Locales for which this template has a translation entry. Mirrors the
+ * global `SupportedLocale` exactly — the four locales the rest of the
+ * app supports. Tightening the prop type to a runtime-checked union
+ * keeps the type honest: callers can't pass a value the template
+ * doesn't actually translate.
  *
  * To add a new locale, extend both this union AND the `translations`
  * record below.
  */
-export type AppointmentReminderLocale = 'en' | 'pt';
+export type AppointmentReminderLocale = 'en' | 'pt' | 'es' | 'br';
 
 interface AppointmentReminderEmailProps {
   patientName?: string;
@@ -69,11 +68,21 @@ export const AppointmentReminderEmail = ({
   meetingLink,
   locale = 'en',
 }: AppointmentReminderEmailProps) => {
+  // Defensive default: callers occasionally forward an empty string when
+  // the upstream `eventName` is missing. Without this guard the inbox
+  // preview would read "...tomorrow - " (trailing dash + nothing) and the
+  // banner / heading would render an empty paragraph. Keep the same neutral
+  // fallback the prop default uses.
+  const safeAppointmentType =
+    typeof appointmentType === 'string' && appointmentType.trim().length > 0
+      ? appointmentType
+      : 'Your appointment';
+
   // Internationalization support
   const translations = {
     en: {
       subject: `Reminder: Your appointment with ${expertName} is tomorrow`,
-      previewText: `Reminder: Your appointment with ${expertName} is tomorrow - ${appointmentType}`,
+      previewText: `Reminder: Your appointment with ${expertName} is tomorrow - ${safeAppointmentType}`,
       title: 'Appointment Reminder',
       greeting: `Hello ${patientName}, this is a friendly reminder about your upcoming appointment.`,
       yourExpert: 'Your Expert',
@@ -95,7 +104,7 @@ export const AppointmentReminderEmail = ({
     },
     pt: {
       subject: `Lembrete: A sua consulta com ${expertName} é amanhã`,
-      previewText: `Lembrete: A sua consulta com ${expertName} é amanhã - ${appointmentType}`,
+      previewText: `Lembrete: A sua consulta com ${expertName} é amanhã - ${safeAppointmentType}`,
       title: 'Lembrete de Consulta',
       greeting: `Olá ${patientName}, este é um lembrete amigável sobre a sua próxima consulta.`,
       yourExpert: 'O Seu Especialista',
@@ -114,6 +123,54 @@ export const AppointmentReminderEmail = ({
       supportText: 'Se tiver alguma dúvida ou precisar de suporte, contacte a nossa equipa.',
       footerText:
         'Se tiver alguma dúvida ou precisar de alterar a sua consulta, contacte a nossa equipa de suporte.',
+    },
+    // Brazilian Portuguese — mostly mirrors `pt` but uses Brazilian vocabulary
+    // ("conexão de internet" stays the same, but "equipa" → "equipe",
+    // "atual" stays, "videochamada" stays as it's understood in both).
+    br: {
+      subject: `Lembrete: Sua consulta com ${expertName} é amanhã`,
+      previewText: `Lembrete: Sua consulta com ${expertName} é amanhã - ${safeAppointmentType}`,
+      title: 'Lembrete de Consulta',
+      greeting: `Olá ${patientName}, este é um lembrete amigável sobre sua próxima consulta.`,
+      yourExpert: 'Seu Especialista',
+      date: 'Data',
+      time: 'Hora',
+      duration: 'Duração',
+      minutes: 'minutos',
+      timezoneLabel: 'Fuso Horário',
+      joinVideoCall: 'Entrar na Videochamada',
+      howToPrepare: 'Como se preparar',
+      prepareItem1: 'Tenha seu histórico médico e medicamentos atuais à mão',
+      prepareItem2: 'Prepare as perguntas que gostaria de discutir',
+      prepareItem3: 'Garanta uma conexão de internet estável para a videochamada',
+      prepareItem4: 'Entre na reunião 5 minutos antes',
+      needAssistance: 'Precisa de ajuda?',
+      supportText: 'Se tiver alguma dúvida ou precisar de suporte, entre em contato com nossa equipe.',
+      footerText:
+        'Se tiver alguma dúvida ou precisar alterar sua consulta, entre em contato com nossa equipe de suporte.',
+    },
+    es: {
+      subject: `Recordatorio: Su cita con ${expertName} es mañana`,
+      previewText: `Recordatorio: Su cita con ${expertName} es mañana - ${safeAppointmentType}`,
+      title: 'Recordatorio de Cita',
+      greeting: `Hola ${patientName}, este es un recordatorio amistoso sobre su próxima cita.`,
+      yourExpert: 'Su Experto',
+      date: 'Fecha',
+      time: 'Hora',
+      duration: 'Duración',
+      minutes: 'minutos',
+      timezoneLabel: 'Zona Horaria',
+      joinVideoCall: 'Unirse a la Videollamada',
+      howToPrepare: 'Cómo prepararse',
+      prepareItem1: 'Tenga su historial médico y medicamentos actuales a mano',
+      prepareItem2: 'Prepare las preguntas que le gustaría discutir',
+      prepareItem3: 'Asegúrese de tener una conexión a internet estable para la videollamada',
+      prepareItem4: 'Únase a la reunión 5 minutos antes',
+      needAssistance: '¿Necesita ayuda?',
+      supportText:
+        'Si tiene alguna pregunta o necesita asistencia, póngase en contacto con nuestro equipo.',
+      footerText:
+        'Si tiene alguna pregunta o necesita modificar su cita, póngase en contacto con nuestro equipo de soporte.',
     },
   };
 
@@ -148,7 +205,7 @@ export const AppointmentReminderEmail = ({
             fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
           }}
         >
-          {appointmentType}
+          {safeAppointmentType}
         </Text>
       </Section>
 
@@ -167,7 +224,7 @@ export const AppointmentReminderEmail = ({
             paddingBottom: '12px',
           }}
         >
-          {appointmentType}
+          {safeAppointmentType}
         </Heading>
 
         <table style={{ width: '100%', borderCollapse: 'collapse' }}>

--- a/emails/experts/marketplace-event.tsx
+++ b/emails/experts/marketplace-event.tsx
@@ -1,0 +1,200 @@
+import * as React from 'react';
+import { EmailLayout } from '@/components/emails';
+import {
+  ELEVA_CARD_STYLES,
+  ELEVA_COLORS,
+  ELEVA_TEXT_STYLES,
+  ELEVA_TYPOGRAPHY,
+} from '@/emails/utils/brand-constants';
+import type { SupportedLocale } from '@/emails/utils/i18n';
+import { Heading, Section, Text } from '@react-email/components';
+
+/**
+ * Locales the marketplace event template ships translations for. The
+ * union mirrors the global `SupportedLocale` so callers can't pass a
+ * value the template doesn't actually translate.
+ */
+export type MarketplaceEventLocale = 'en' | 'pt' | 'es' | 'br';
+
+/**
+ * `marketplace-universal` workflow event types we know about. Used to
+ * drive the headline / icon — the body itself is taken verbatim from
+ * the `message` payload field.
+ */
+export type MarketplaceEventType =
+  | 'payment-received'
+  | 'payout-processed'
+  | 'connect-account-status'
+  | 'refund-processed';
+
+interface MarketplaceEventEmailProps {
+  expertName?: string;
+  /**
+   * Localized message to render in the body card. Comes straight from
+   * the workflow trigger (e.g. `"You received a payment of EUR 70.00..."`).
+   * Rendered verbatim — callers are responsible for localization.
+   */
+  message?: string;
+  amount?: string;
+  currency?: string;
+  accountStatus?: string;
+  eventType?: MarketplaceEventType;
+  /** Optional CTA button. Hidden when both `actionUrl` and `actionText` are absent. */
+  actionUrl?: string;
+  actionText?: string;
+  locale?: MarketplaceEventLocale;
+}
+
+const ICONS: Record<MarketplaceEventType, string> = {
+  'payment-received': '💰',
+  'payout-processed': '🏦',
+  'connect-account-status': '🔧',
+  'refund-processed': '↩️',
+};
+
+const HEADINGS: Record<MarketplaceEventLocale, Record<MarketplaceEventType, string>> = {
+  en: {
+    'payment-received': 'Payment received',
+    'payout-processed': 'Payout processed',
+    'connect-account-status': 'Account update',
+    'refund-processed': 'Refund processed',
+  },
+  pt: {
+    'payment-received': 'Pagamento recebido',
+    'payout-processed': 'Transferência processada',
+    'connect-account-status': 'Atualização de conta',
+    'refund-processed': 'Reembolso processado',
+  },
+  br: {
+    'payment-received': 'Pagamento recebido',
+    'payout-processed': 'Repasse processado',
+    'connect-account-status': 'Atualização de conta',
+    'refund-processed': 'Reembolso processado',
+  },
+  es: {
+    'payment-received': 'Pago recibido',
+    'payout-processed': 'Pago procesado',
+    'connect-account-status': 'Actualización de cuenta',
+    'refund-processed': 'Reembolso procesado',
+  },
+};
+
+/**
+ * Branded React Email template for the `marketplace-universal` Novu
+ * workflow. Replaces the inline HTML body that previously shipped from
+ * `config/novu.ts` (no branding, no localization, no CTA). Used for
+ * expert-side notifications about marketplace events: payment received,
+ * payout processed, Connect account status changes, and refund
+ * processed (from `notifyAppointmentConflict`).
+ */
+export const MarketplaceEventEmail = ({
+  expertName = 'Expert',
+  message = '',
+  amount,
+  currency = 'EUR',
+  accountStatus,
+  eventType = 'payment-received',
+  actionUrl,
+  actionText,
+  locale = 'en',
+}: MarketplaceEventEmailProps) => {
+  const heading = HEADINGS[locale][eventType];
+  const icon = ICONS[eventType];
+  const subject = `${icon} ${heading} - Eleva Care`;
+  const trimmedMessage = (message || '').trim();
+  const previewText = trimmedMessage.length
+    ? `${heading}: ${trimmedMessage.length > 100 ? `${trimmedMessage.substring(0, 100)}...` : trimmedMessage}`
+    : heading;
+
+  const greeting =
+    locale === 'pt' || locale === 'br'
+      ? `Olá ${expertName},`
+      : locale === 'es'
+        ? `Hola ${expertName},`
+        : `Hello ${expertName},`;
+
+  return (
+    <EmailLayout
+      subject={subject}
+      previewText={previewText}
+      headerVariant="branded"
+      footerVariant="default"
+      locale={locale satisfies SupportedLocale}
+    >
+      <Section style={ELEVA_CARD_STYLES.success}>
+        <Heading
+          style={{
+            ...ELEVA_TEXT_STYLES.heading2,
+            margin: '0 0 8px 0',
+            textAlign: 'center' as const,
+          }}
+        >
+          {icon} {heading}
+        </Heading>
+        {amount && (
+          <Text
+            style={{
+              ...ELEVA_TEXT_STYLES.bodyLarge,
+              margin: '0',
+              textAlign: 'center' as const,
+              fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
+              color: ELEVA_COLORS.primary,
+            }}
+          >
+            {currency} {amount}
+          </Text>
+        )}
+      </Section>
+
+      <Section style={{ margin: '32px 0' }}>
+        <Text style={{ ...ELEVA_TEXT_STYLES.bodyLarge, margin: '0 0 16px 0' }}>{greeting}</Text>
+        {trimmedMessage && (
+          <Text style={ELEVA_TEXT_STYLES.bodyRegular}>{trimmedMessage}</Text>
+        )}
+        {accountStatus && (
+          <Text
+            style={{
+              ...ELEVA_TEXT_STYLES.bodyRegular,
+              marginTop: '16px',
+              color: ELEVA_COLORS.neutral.dark,
+            }}
+          >
+            <strong>Status:</strong> {accountStatus}
+          </Text>
+        )}
+      </Section>
+
+      {actionUrl && actionText && (
+        <Section style={{ textAlign: 'center', margin: '32px 0' }}>
+          <a
+            href={actionUrl}
+            style={{
+              display: 'inline-block',
+              backgroundColor: ELEVA_COLORS.primary,
+              color: ELEVA_COLORS.surface,
+              padding: '14px 28px',
+              borderRadius: '8px',
+              textDecoration: 'none',
+              fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
+            }}
+          >
+            {actionText}
+          </a>
+        </Section>
+      )}
+    </EmailLayout>
+  );
+};
+
+export default MarketplaceEventEmail;
+
+MarketplaceEventEmail.PreviewProps = {
+  expertName: 'Dr. Patricia Mota',
+  message: 'You received a payment of EUR 70.00 for a session with Marta Carvalho.',
+  amount: '70.00',
+  currency: 'EUR',
+  eventType: 'payment-received',
+  actionUrl: 'https://eleva.care/dashboard/earnings',
+  actionText: 'View earnings',
+  locale: 'en',
+} as MarketplaceEventEmailProps;

--- a/emails/experts/marketplace-event.tsx
+++ b/emails/experts/marketplace-event.tsx
@@ -52,6 +52,12 @@ const ICONS: Record<MarketplaceEventType, string> = {
   'refund-processed': '↩️',
 };
 
+// Heading translations are kept in this file (rather than in a shared
+// `emails/utils/i18n` helper) on purpose: they are template-specific copy
+// keyed by `MarketplaceEventType`, exhaustively typed, and used in exactly
+// one place. Promoting them to a shared util would just relocate the same
+// 16 strings without giving any other template a useful contract — the
+// labels here have no overlap with other templates' translation tables.
 const HEADINGS: Record<MarketplaceEventLocale, Record<MarketplaceEventType, string>> = {
   en: {
     'payment-received': 'Payment received',

--- a/emails/packs/pack-purchase-confirmation.tsx
+++ b/emails/packs/pack-purchase-confirmation.tsx
@@ -315,32 +315,39 @@ export const PackPurchaseConfirmation = ({
         </Section>
       )}
 
-      <Section style={ELEVA_CARD_STYLES.default}>
-        <Heading style={{ ...ELEVA_TEXT_STYLES.heading3, margin: '0 0 16px 0' }}>
-          {t.howToUse}
-        </Heading>
-        <table style={{ width: '100%', borderCollapse: 'collapse' as const }}>
-          {[t.step1, t.step2, t.step3, t.step4].map((step, index) => (
-            <tr key={index}>
-              <td
-                style={{
-                  padding: '8px 12px 8px 0',
-                  verticalAlign: 'top' as const,
-                  width: '32px',
-                  fontSize: '16px',
-                  fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
-                  color: ELEVA_COLORS.primary,
-                }}
-              >
-                {index + 1}.
-              </td>
-              <td style={{ padding: '8px 0', ...ELEVA_TEXT_STYLES.bodyRegular, margin: 0 }}>
-                {step}
-              </td>
-            </tr>
-          ))}
-        </table>
-      </Section>
+      {/* "How to use your code" steps reference the promo code in the
+          previous block. If we don't have a code to redeem, omit the steps
+          entirely — otherwise the buyer sees redemption instructions
+          ("Visit your expert's booking page... Enter the code...") with
+          no code to enter. */}
+      {promotionCode && (
+        <Section style={ELEVA_CARD_STYLES.default}>
+          <Heading style={{ ...ELEVA_TEXT_STYLES.heading3, margin: '0 0 16px 0' }}>
+            {t.howToUse}
+          </Heading>
+          <table style={{ width: '100%', borderCollapse: 'collapse' as const }}>
+            {[t.step1, t.step2, t.step3, t.step4].map((step, index) => (
+              <tr key={index}>
+                <td
+                  style={{
+                    padding: '8px 12px 8px 0',
+                    verticalAlign: 'top' as const,
+                    width: '32px',
+                    fontSize: '16px',
+                    fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
+                    color: ELEVA_COLORS.primary,
+                  }}
+                >
+                  {index + 1}.
+                </td>
+                <td style={{ padding: '8px 0', ...ELEVA_TEXT_STYLES.bodyRegular, margin: 0 }}>
+                  {step}
+                </td>
+              </tr>
+            ))}
+          </table>
+        </Section>
+      )}
 
       <Section style={{ textAlign: 'center' as const, margin: '32px 0' }}>
         <EmailButton

--- a/emails/packs/pack-purchase-confirmation.tsx
+++ b/emails/packs/pack-purchase-confirmation.tsx
@@ -171,7 +171,12 @@ export const PackPurchaseConfirmation = ({
       : '—';
 
   const subject = `${t.successTitle} - ${packName}`;
-  const previewText = `${t.promoInstructions} ${promotionCode}`;
+  // Only append the promo code to the inbox preview when it's actually
+  // present. Without this guard the preview reads "Use the code  to redeem"
+  // (double space + dangling clause) when the code is missing.
+  const previewText = promotionCode
+    ? `${t.promoInstructions} ${promotionCode}`
+    : t.successTitle;
 
   return (
     <EmailLayout
@@ -259,51 +264,56 @@ export const PackPurchaseConfirmation = ({
         </table>
       </Section>
 
-      <Section
-        style={{
-          margin: '32px 0',
-          padding: '32px',
-          backgroundColor: ELEVA_COLORS.neutral.extraLight,
-          borderRadius: '12px',
-          border: `2px dashed ${ELEVA_COLORS.primary}`,
-          textAlign: 'center' as const,
-        }}
-      >
-        <Text
+      {/* Only render the promo block when there is actually a code to show.
+          An empty dashed border with no code in the middle would look like
+          a layout bug to the buyer. */}
+      {promotionCode && (
+        <Section
           style={{
-            ...ELEVA_TEXT_STYLES.heading3,
-            margin: '0 0 12px 0',
-            color: ELEVA_COLORS.primary,
-          }}
-        >
-          {t.promoTitle}
-        </Text>
-        <Text style={{ ...ELEVA_TEXT_STYLES.bodyRegular, margin: '0 0 20px 0' }}>
-          {t.promoInstructions}
-        </Text>
-        <div
-          style={{
-            display: 'inline-block',
-            padding: '16px 32px',
-            backgroundColor: ELEVA_COLORS.surface,
-            borderRadius: '8px',
-            border: `2px solid ${ELEVA_COLORS.primary}`,
+            margin: '32px 0',
+            padding: '32px',
+            backgroundColor: ELEVA_COLORS.neutral.extraLight,
+            borderRadius: '12px',
+            border: `2px dashed ${ELEVA_COLORS.primary}`,
+            textAlign: 'center' as const,
           }}
         >
           <Text
             style={{
-              margin: '0',
-              fontSize: '28px',
-              fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
-              fontFamily: 'monospace',
+              ...ELEVA_TEXT_STYLES.heading3,
+              margin: '0 0 12px 0',
               color: ELEVA_COLORS.primary,
-              letterSpacing: '3px',
             }}
           >
-            {promotionCode}
+            {t.promoTitle}
           </Text>
-        </div>
-      </Section>
+          <Text style={{ ...ELEVA_TEXT_STYLES.bodyRegular, margin: '0 0 20px 0' }}>
+            {t.promoInstructions}
+          </Text>
+          <div
+            style={{
+              display: 'inline-block',
+              padding: '16px 32px',
+              backgroundColor: ELEVA_COLORS.surface,
+              borderRadius: '8px',
+              border: `2px solid ${ELEVA_COLORS.primary}`,
+            }}
+          >
+            <Text
+              style={{
+                margin: '0',
+                fontSize: '28px',
+                fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
+                fontFamily: 'monospace',
+                color: ELEVA_COLORS.primary,
+                letterSpacing: '3px',
+              }}
+            >
+              {promotionCode}
+            </Text>
+          </div>
+        </Section>
+      )}
 
       <Section style={ELEVA_CARD_STYLES.default}>
         <Heading style={{ ...ELEVA_TEXT_STYLES.heading3, margin: '0 0 16px 0' }}>

--- a/emails/payments/multibanco-booking-pending.tsx
+++ b/emails/payments/multibanco-booking-pending.tsx
@@ -192,12 +192,14 @@ export default function MultibancoBookingPendingTemplate({
         </Heading>
 
         <table style={{ width: '100%', borderCollapse: 'collapse' as const }}>
-          <tr>
-            <td style={createTableCellStyle(true)}>{t.service}:</td>
-            <td style={{ ...createTableCellStyle(false, 'right'), color: ELEVA_COLORS.primary }}>
-              {serviceName}
-            </td>
-          </tr>
+          {serviceName && (
+            <tr>
+              <td style={createTableCellStyle(true)}>{t.service}:</td>
+              <td style={{ ...createTableCellStyle(false, 'right'), color: ELEVA_COLORS.primary }}>
+                {serviceName}
+              </td>
+            </tr>
+          )}
           {appointmentDate && (
             <tr>
               <td style={createTableCellStyle(true)}>{t.date}:</td>
@@ -221,12 +223,14 @@ export default function MultibancoBookingPendingTemplate({
               </td>
             </tr>
           )}
-          <tr>
-            <td style={createTableCellStyle(true)}>Expert:</td>
-            <td style={{ ...createTableCellStyle(false, 'right'), color: ELEVA_COLORS.primary }}>
-              {expertName}
-            </td>
-          </tr>
+          {expertName && (
+            <tr>
+              <td style={createTableCellStyle(true)}>Expert:</td>
+              <td style={{ ...createTableCellStyle(false, 'right'), color: ELEVA_COLORS.primary }}>
+                {expertName}
+              </td>
+            </tr>
+          )}
           {customerNotes && (
             <tr>
               <td style={createTableCellStyle(true)}>{t.notes}:</td>
@@ -259,89 +263,97 @@ export default function MultibancoBookingPendingTemplate({
         </Heading>
 
         <table style={{ width: '100%', borderCollapse: 'collapse' as const }}>
-          <tr>
-            <td
-              style={{
-                ...createTableCellStyle(true),
-                color: ELEVA_COLORS.error,
-                fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
-              }}
-            >
-              {t.entity}:
-            </td>
-            <td
-              style={{
-                ...createTableCellStyle(false, 'right'),
-                fontFamily: 'monospace',
-                fontSize: '18px',
-                fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
-              }}
-            >
-              {multibancoEntity}
-            </td>
-          </tr>
-          <tr>
-            <td
-              style={{
-                ...createTableCellStyle(true),
-                color: ELEVA_COLORS.error,
-                fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
-              }}
-            >
-              {t.reference}:
-            </td>
-            <td
-              style={{
-                ...createTableCellStyle(false, 'right'),
-                fontFamily: 'monospace',
-                fontSize: '18px',
-                fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
-              }}
-            >
-              {multibancoReference}
-            </td>
-          </tr>
-          <tr>
-            <td
-              style={{
-                ...createTableCellStyle(true),
-                color: ELEVA_COLORS.error,
-                fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
-              }}
-            >
-              {t.amount}:
-            </td>
-            <td
-              style={{
-                ...createTableCellStyle(false, 'right'),
-                fontSize: '20px',
-                fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
-                color: ELEVA_COLORS.success,
-              }}
-            >
-              €{multibancoAmount}
-            </td>
-          </tr>
-          <tr>
-            <td
-              style={{
-                ...createTableCellStyle(true),
-                color: ELEVA_COLORS.error,
-                fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
-              }}
-            >
-              {t.expires}:
-            </td>
-            <td
-              style={{
-                ...createTableCellStyle(false, 'right'),
-                fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
-                color: ELEVA_COLORS.error,
-              }}
-            >
-              {voucherExpiresAt}
-            </td>
-          </tr>
+          {multibancoEntity && (
+            <tr>
+              <td
+                style={{
+                  ...createTableCellStyle(true),
+                  color: ELEVA_COLORS.error,
+                  fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
+                }}
+              >
+                {t.entity}:
+              </td>
+              <td
+                style={{
+                  ...createTableCellStyle(false, 'right'),
+                  fontFamily: 'monospace',
+                  fontSize: '18px',
+                  fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
+                }}
+              >
+                {multibancoEntity}
+              </td>
+            </tr>
+          )}
+          {multibancoReference && (
+            <tr>
+              <td
+                style={{
+                  ...createTableCellStyle(true),
+                  color: ELEVA_COLORS.error,
+                  fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
+                }}
+              >
+                {t.reference}:
+              </td>
+              <td
+                style={{
+                  ...createTableCellStyle(false, 'right'),
+                  fontFamily: 'monospace',
+                  fontSize: '18px',
+                  fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
+                }}
+              >
+                {multibancoReference}
+              </td>
+            </tr>
+          )}
+          {multibancoAmount && multibancoAmount !== '0.00' && (
+            <tr>
+              <td
+                style={{
+                  ...createTableCellStyle(true),
+                  color: ELEVA_COLORS.error,
+                  fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
+                }}
+              >
+                {t.amount}:
+              </td>
+              <td
+                style={{
+                  ...createTableCellStyle(false, 'right'),
+                  fontSize: '20px',
+                  fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
+                  color: ELEVA_COLORS.success,
+                }}
+              >
+                €{multibancoAmount}
+              </td>
+            </tr>
+          )}
+          {voucherExpiresAt && (
+            <tr>
+              <td
+                style={{
+                  ...createTableCellStyle(true),
+                  color: ELEVA_COLORS.error,
+                  fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
+                }}
+              >
+                {t.expires}:
+              </td>
+              <td
+                style={{
+                  ...createTableCellStyle(false, 'right'),
+                  fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
+                  color: ELEVA_COLORS.error,
+                }}
+              >
+                {voucherExpiresAt}
+              </td>
+            </tr>
+          )}
         </table>
 
         <Text

--- a/emails/payments/multibanco-booking-pending.tsx
+++ b/emails/payments/multibanco-booking-pending.tsx
@@ -60,8 +60,13 @@ interface MultibancoBookingPendingProps {
  */
 export default function MultibancoBookingPendingTemplate({
   customerName = 'Customer',
-  expertName = 'Your Expert',
-  serviceName = 'Your appointment',
+  // `expertName` and `serviceName` intentionally have NO default: the
+  // detail-table rows below render conditionally on these props being
+  // truthy non-empty strings, so a non-empty default would defeat the
+  // guard and render rows with placeholder text ("Your Expert" /
+  // "Your appointment") even when the adapter omitted the fields.
+  expertName,
+  serviceName,
   appointmentDate = '',
   appointmentTime = '',
   timezone = '',
@@ -74,17 +79,27 @@ export default function MultibancoBookingPendingTemplate({
   customerNotes,
   locale = 'en',
 }: MultibancoBookingPendingProps) {
+  // Use derived values for translation interpolation so subject /
+  // previewText / mainMessage stay readable when the props are missing,
+  // without re-introducing fallbacks into the conditional table rows.
+  const expertLabel =
+    typeof expertName === 'string' && expertName.trim().length > 0
+      ? expertName
+      : locale === 'pt'
+        ? 'o seu especialista'
+        : 'your expert';
   // Internationalization support
   const translations = {
     en: {
-      subject: `Appointment with ${expertName} - Payment Pending via Multibanco`,
-      previewText: `Complete your booking with ${expertName} by paying via Multibanco`,
+      subject: `Appointment with ${expertLabel} - Payment Pending via Multibanco`,
+      previewText: `Complete your booking with ${expertLabel} by paying via Multibanco`,
       title: 'Payment Pending - Complete Your Booking',
       greeting: 'Hello',
-      mainMessage: `We've reserved your appointment with <strong>${expertName}</strong> and are waiting for your payment confirmation via Multibanco.`,
+      mainMessage: `We've reserved your appointment with <strong>${expertLabel}</strong> and are waiting for your payment confirmation via Multibanco.`,
       appointmentDetails: 'Appointment Details',
       paymentDetails: 'Multibanco Payment Details',
       service: 'Service',
+      expert: 'Expert',
       date: 'Date',
       time: 'Time',
       duration: 'Duration',
@@ -101,14 +116,15 @@ export default function MultibancoBookingPendingTemplate({
       paymentUrgent: 'Payment required to secure your appointment',
     },
     pt: {
-      subject: `Consulta com ${expertName} - Pagamento Pendente via Multibanco`,
-      previewText: `Complete a sua marcação com ${expertName} pagando via Multibanco`,
+      subject: `Consulta com ${expertLabel} - Pagamento Pendente via Multibanco`,
+      previewText: `Complete a sua marcação com ${expertLabel} pagando via Multibanco`,
       title: 'Pagamento Pendente - Complete a Sua Marcação',
       greeting: 'Olá',
-      mainMessage: `Reservámos a sua consulta com <strong>${expertName}</strong> e aguardamos a confirmação do pagamento via Multibanco.`,
+      mainMessage: `Reservámos a sua consulta com <strong>${expertLabel}</strong> e aguardamos a confirmação do pagamento via Multibanco.`,
       appointmentDetails: 'Detalhes da Consulta',
       paymentDetails: 'Detalhes do Pagamento Multibanco',
       service: 'Serviço',
+      expert: 'Especialista',
       date: 'Data',
       time: 'Hora',
       duration: 'Duração',
@@ -192,7 +208,7 @@ export default function MultibancoBookingPendingTemplate({
         </Heading>
 
         <table style={{ width: '100%', borderCollapse: 'collapse' as const }}>
-          {serviceName && (
+          {serviceName && serviceName.trim().length > 0 && (
             <tr>
               <td style={createTableCellStyle(true)}>{t.service}:</td>
               <td style={{ ...createTableCellStyle(false, 'right'), color: ELEVA_COLORS.primary }}>
@@ -223,9 +239,9 @@ export default function MultibancoBookingPendingTemplate({
               </td>
             </tr>
           )}
-          {expertName && (
+          {expertName && expertName.trim().length > 0 && (
             <tr>
-              <td style={createTableCellStyle(true)}>Expert:</td>
+              <td style={createTableCellStyle(true)}>{t.expert}:</td>
               <td style={{ ...createTableCellStyle(false, 'right'), color: ELEVA_COLORS.primary }}>
                 {expertName}
               </td>

--- a/emails/payments/multibanco-payment-reminder.tsx
+++ b/emails/payments/multibanco-payment-reminder.tsx
@@ -42,8 +42,13 @@ interface MultibancoPaymentReminderProps {
 // See plan: fix_fake_email_content_bug.
 export default function MultibancoPaymentReminderTemplate({
   customerName = 'Customer',
-  expertName = 'Your Expert',
-  serviceName = 'Your appointment',
+  // `expertName` and `serviceName` intentionally have NO default: the
+  // detail-table rows below render conditionally on these props being
+  // truthy non-empty strings, so a non-empty default would defeat the
+  // guard and render rows with placeholder text ("Your Expert" /
+  // "Your appointment") even when the adapter omitted the fields.
+  expertName,
+  serviceName,
   appointmentDate = '',
   appointmentTime = '',
   timezone = '',
@@ -59,6 +64,22 @@ export default function MultibancoPaymentReminderTemplate({
   locale = 'en',
 }: MultibancoPaymentReminderProps) {
   const isUrgent = reminderType === 'urgent' || daysRemaining <= 1;
+
+  // Locale-aware fallbacks for subject / previewText interpolation when
+  // the prop is missing — keeps the inbox preview readable while leaving
+  // the conditional table rows below to omit themselves entirely.
+  const expertLabel =
+    typeof expertName === 'string' && expertName.trim().length > 0
+      ? expertName
+      : locale === 'pt'
+        ? 'o seu especialista'
+        : 'your expert';
+  const serviceLabel =
+    typeof serviceName === 'string' && serviceName.trim().length > 0
+      ? serviceName
+      : locale === 'pt'
+        ? 'a sua consulta'
+        : 'your appointment';
 
   // `duration` may arrive as either a number of minutes or a pre-formatted
   // string. Normalize to a render-ready label and a "should we show the
@@ -84,17 +105,18 @@ export default function MultibancoPaymentReminderTemplate({
   const translations = {
     en: {
       urgent: 'URGENT',
-      subject: `Payment Reminder - Appointment with ${expertName}`,
-      subjectUrgent: `URGENT: Payment Reminder - Appointment with ${expertName}`,
-      previewText: `Your payment for the appointment with ${expertName} expires soon`,
-      previewTextUrgent: `URGENT: Your payment for the appointment with ${expertName} expires soon`,
-      title: `Payment Reminder - ${serviceName}`,
+      subject: `Payment Reminder - Appointment with ${expertLabel}`,
+      subjectUrgent: `URGENT: Payment Reminder - Appointment with ${expertLabel}`,
+      previewText: `Your payment for the appointment with ${expertLabel} expires soon`,
+      previewTextUrgent: `URGENT: Your payment for the appointment with ${expertLabel} expires soon`,
+      title: `Payment Reminder - ${serviceLabel}`,
       greeting: 'Hello',
-      reminderMessage: `This is a ${reminderType} reminder that your payment for the appointment with <strong>${expertName}</strong> is still pending and will expire soon.`,
+      reminderMessage: `This is a ${reminderType} reminder that your payment for the appointment with <strong>${expertLabel}</strong> is still pending and will expire soon.`,
       urgentWarning: `⚠️ Don't lose your appointment! Payment expires in ${daysRemaining} day${daysRemaining !== 1 ? 's' : ''}.`,
       appointmentDetails: 'Appointment Details',
       paymentDetails: 'Multibanco Payment Details',
       service: 'Service',
+      expert: 'Expert',
       date: 'Date',
       time: 'Time',
       duration: 'Duration',
@@ -116,17 +138,18 @@ export default function MultibancoPaymentReminderTemplate({
     },
     pt: {
       urgent: 'URGENTE',
-      subject: `Lembrete de Pagamento - Consulta com ${expertName}`,
-      subjectUrgent: `URGENTE: Lembrete de Pagamento - Consulta com ${expertName}`,
-      previewText: `O seu pagamento para a consulta com ${expertName} expira em breve`,
-      previewTextUrgent: `URGENTE: O seu pagamento para a consulta com ${expertName} expira em breve`,
-      title: `Lembrete de Pagamento - ${serviceName}`,
+      subject: `Lembrete de Pagamento - Consulta com ${expertLabel}`,
+      subjectUrgent: `URGENTE: Lembrete de Pagamento - Consulta com ${expertLabel}`,
+      previewText: `O seu pagamento para a consulta com ${expertLabel} expira em breve`,
+      previewTextUrgent: `URGENTE: O seu pagamento para a consulta com ${expertLabel} expira em breve`,
+      title: `Lembrete de Pagamento - ${serviceLabel}`,
       greeting: 'Olá',
-      reminderMessage: `Este é um lembrete ${reminderType === 'urgent' ? 'urgente' : 'gentil'} de que o seu pagamento para a consulta com <strong>${expertName}</strong> ainda está pendente e expirará em breve.`,
+      reminderMessage: `Este é um lembrete ${reminderType === 'urgent' ? 'urgente' : 'gentil'} de que o seu pagamento para a consulta com <strong>${expertLabel}</strong> ainda está pendente e expirará em breve.`,
       urgentWarning: `⚠️ Não perca a sua consulta! O pagamento expira em ${daysRemaining} dia${daysRemaining !== 1 ? 's' : ''}.`,
       appointmentDetails: 'Detalhes da Consulta',
       paymentDetails: 'Detalhes do Pagamento Multibanco',
       service: 'Serviço',
+      expert: 'Especialista',
       date: 'Data',
       time: 'Hora',
       duration: 'Duração',
@@ -239,7 +262,7 @@ export default function MultibancoPaymentReminderTemplate({
         </Heading>
 
         <table style={{ width: '100%', borderCollapse: 'collapse' as const }}>
-          {serviceName && (
+          {serviceName && serviceName.trim().length > 0 && (
             <tr>
               <td style={createTableCellStyle(true)}>{t.service}:</td>
               <td style={{ ...createTableCellStyle(false, 'right'), color: ELEVA_COLORS.primary }}>
@@ -273,9 +296,9 @@ export default function MultibancoPaymentReminderTemplate({
               </td>
             </tr>
           )}
-          {expertName && (
+          {expertName && expertName.trim().length > 0 && (
             <tr>
-              <td style={createTableCellStyle(true)}>Expert:</td>
+              <td style={createTableCellStyle(true)}>{t.expert}:</td>
               <td style={{ ...createTableCellStyle(false, 'right'), color: ELEVA_COLORS.primary }}>
                 {expertName}
               </td>

--- a/emails/payments/multibanco-payment-reminder.tsx
+++ b/emails/payments/multibanco-payment-reminder.tsx
@@ -239,12 +239,14 @@ export default function MultibancoPaymentReminderTemplate({
         </Heading>
 
         <table style={{ width: '100%', borderCollapse: 'collapse' as const }}>
-          <tr>
-            <td style={createTableCellStyle(true)}>{t.service}:</td>
-            <td style={{ ...createTableCellStyle(false, 'right'), color: ELEVA_COLORS.primary }}>
-              {serviceName}
-            </td>
-          </tr>
+          {serviceName && (
+            <tr>
+              <td style={createTableCellStyle(true)}>{t.service}:</td>
+              <td style={{ ...createTableCellStyle(false, 'right'), color: ELEVA_COLORS.primary }}>
+                {serviceName}
+              </td>
+            </tr>
+          )}
           {appointmentDate && (
             <tr>
               <td style={createTableCellStyle(true)}>{t.date}:</td>
@@ -271,12 +273,14 @@ export default function MultibancoPaymentReminderTemplate({
               </td>
             </tr>
           )}
-          <tr>
-            <td style={createTableCellStyle(true)}>Expert:</td>
-            <td style={{ ...createTableCellStyle(false, 'right'), color: ELEVA_COLORS.primary }}>
-              {expertName}
-            </td>
-          </tr>
+          {expertName && (
+            <tr>
+              <td style={createTableCellStyle(true)}>Expert:</td>
+              <td style={{ ...createTableCellStyle(false, 'right'), color: ELEVA_COLORS.primary }}>
+                {expertName}
+              </td>
+            </tr>
+          )}
           {customerNotes && (
             <tr>
               <td style={createTableCellStyle(true)}>{t.notes}:</td>
@@ -309,90 +313,98 @@ export default function MultibancoPaymentReminderTemplate({
         </Heading>
 
         <table style={{ width: '100%', borderCollapse: 'collapse' as const }}>
-          <tr>
-            <td
-              style={{
-                ...createTableCellStyle(true),
-                color: isUrgent ? ELEVA_COLORS.error : ELEVA_COLORS.warning,
-                fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
-              }}
-            >
-              {t.entity}:
-            </td>
-            <td
-              style={{
-                ...createTableCellStyle(false, 'right'),
-                fontFamily: 'monospace',
-                fontSize: '18px',
-                fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
-              }}
-            >
-              {multibancoEntity}
-            </td>
-          </tr>
-          <tr>
-            <td
-              style={{
-                ...createTableCellStyle(true),
-                color: isUrgent ? ELEVA_COLORS.error : ELEVA_COLORS.warning,
-                fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
-              }}
-            >
-              {t.reference}:
-            </td>
-            <td
-              style={{
-                ...createTableCellStyle(false, 'right'),
-                fontFamily: 'monospace',
-                fontSize: '18px',
-                fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
-              }}
-            >
-              {multibancoReference}
-            </td>
-          </tr>
-          <tr>
-            <td
-              style={{
-                ...createTableCellStyle(true),
-                color: isUrgent ? ELEVA_COLORS.error : ELEVA_COLORS.warning,
-                fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
-              }}
-            >
-              {t.amount}:
-            </td>
-            <td
-              style={{
-                ...createTableCellStyle(false, 'right'),
-                fontSize: '20px',
-                fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
-                color: ELEVA_COLORS.success,
-              }}
-            >
-              €{multibancoAmount}
-            </td>
-          </tr>
-          <tr>
-            <td
-              style={{
-                ...createTableCellStyle(true),
-                color: isUrgent ? ELEVA_COLORS.error : ELEVA_COLORS.warning,
-                fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
-              }}
-            >
-              {t.expires}:
-            </td>
-            <td
-              style={{
-                ...createTableCellStyle(false, 'right'),
-                fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
-                color: isUrgent ? ELEVA_COLORS.error : ELEVA_COLORS.warning,
-                fontSize: '18px',
-              }}
-            >
-              {voucherExpiresAt}
-            </td>
-          </tr>
+          {multibancoEntity && (
+            <tr>
+              <td
+                style={{
+                  ...createTableCellStyle(true),
+                  color: isUrgent ? ELEVA_COLORS.error : ELEVA_COLORS.warning,
+                  fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
+                }}
+              >
+                {t.entity}:
+              </td>
+              <td
+                style={{
+                  ...createTableCellStyle(false, 'right'),
+                  fontFamily: 'monospace',
+                  fontSize: '18px',
+                  fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
+                }}
+              >
+                {multibancoEntity}
+              </td>
+            </tr>
+          )}
+          {multibancoReference && (
+            <tr>
+              <td
+                style={{
+                  ...createTableCellStyle(true),
+                  color: isUrgent ? ELEVA_COLORS.error : ELEVA_COLORS.warning,
+                  fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
+                }}
+              >
+                {t.reference}:
+              </td>
+              <td
+                style={{
+                  ...createTableCellStyle(false, 'right'),
+                  fontFamily: 'monospace',
+                  fontSize: '18px',
+                  fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
+                }}
+              >
+                {multibancoReference}
+              </td>
+            </tr>
+          )}
+          {multibancoAmount && multibancoAmount !== '0.00' && (
+            <tr>
+              <td
+                style={{
+                  ...createTableCellStyle(true),
+                  color: isUrgent ? ELEVA_COLORS.error : ELEVA_COLORS.warning,
+                  fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
+                }}
+              >
+                {t.amount}:
+              </td>
+              <td
+                style={{
+                  ...createTableCellStyle(false, 'right'),
+                  fontSize: '20px',
+                  fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
+                  color: ELEVA_COLORS.success,
+                }}
+              >
+                €{multibancoAmount}
+              </td>
+            </tr>
+          )}
+          {voucherExpiresAt && (
+            <tr>
+              <td
+                style={{
+                  ...createTableCellStyle(true),
+                  color: isUrgent ? ELEVA_COLORS.error : ELEVA_COLORS.warning,
+                  fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
+                }}
+              >
+                {t.expires}:
+              </td>
+              <td
+                style={{
+                  ...createTableCellStyle(false, 'right'),
+                  fontWeight: ELEVA_TYPOGRAPHY.weights.bold,
+                  color: isUrgent ? ELEVA_COLORS.error : ELEVA_COLORS.warning,
+                  fontSize: '18px',
+                }}
+              >
+                {voucherExpiresAt}
+              </td>
+            </tr>
+          )}
         </table>
 
         <Text

--- a/emails/system/system-health-alert.tsx
+++ b/emails/system/system-health-alert.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react';
+import { EmailLayout } from '@/components/emails';
+import {
+  createTableCellStyle,
+  ELEVA_CARD_STYLES,
+  ELEVA_COLORS,
+  ELEVA_TEXT_STYLES,
+  ELEVA_TYPOGRAPHY,
+} from '@/emails/utils/brand-constants';
+import type { SupportedLocale } from '@/emails/utils/i18n';
+import { Heading, Section, Text } from '@react-email/components';
+
+interface SystemHealthAlertEmailProps {
+  /** Numeric percentage 0-100; rendered as part of the memory row. */
+  memoryPercentage?: number;
+  memoryUsed?: number;
+  memoryTotal?: number;
+  status?: 'healthy' | 'unhealthy';
+  environment?: string;
+  error?: string;
+  timestamp?: string;
+  /**
+   * Operational template — admin-facing only, English by default. Locale
+   * support is intentionally minimal because alerts go to a fixed
+   * internal subscriber (NOVU_ADMIN_SUBSCRIBER_ID).
+   */
+  locale?: SupportedLocale;
+}
+
+/**
+ * Branded React Email template for the `system-health` Novu workflow.
+ * Replaces the inline HTML body that previously shipped from
+ * `config/novu.ts` (no branding, no structured rows). Used by the
+ * `/api/healthcheck` endpoint and the Redis webhook monitor.
+ */
+export const SystemHealthAlertEmail = ({
+  memoryPercentage,
+  memoryUsed,
+  memoryTotal,
+  status = 'unhealthy',
+  environment = 'unknown',
+  error,
+  timestamp,
+  locale = 'en',
+}: SystemHealthAlertEmailProps) => {
+  const isUnhealthy = status === 'unhealthy';
+  const subject = `${isUnhealthy ? '⚠️' : '✅'} System Health: ${status} (${environment})`;
+  const previewText = error
+    ? `${status} in ${environment}: ${error.length > 100 ? `${error.substring(0, 100)}...` : error}`
+    : `${status} in ${environment}`;
+
+  return (
+    <EmailLayout
+      subject={subject}
+      previewText={previewText}
+      headerVariant="branded"
+      footerVariant="default"
+      locale={locale}
+    >
+      <Section style={isUnhealthy ? ELEVA_CARD_STYLES.warning : ELEVA_CARD_STYLES.success}>
+        <Heading
+          style={{
+            ...ELEVA_TEXT_STYLES.heading2,
+            margin: '0 0 8px 0',
+            textAlign: 'center' as const,
+            color: isUnhealthy ? ELEVA_COLORS.error : ELEVA_COLORS.success,
+          }}
+        >
+          {isUnhealthy ? '⚠️' : '✅'} System {status}
+        </Heading>
+        <Text
+          style={{
+            ...ELEVA_TEXT_STYLES.bodyRegular,
+            margin: '0',
+            textAlign: 'center' as const,
+            fontWeight: ELEVA_TYPOGRAPHY.weights.medium,
+          }}
+        >
+          Environment: <strong>{environment}</strong>
+        </Text>
+      </Section>
+
+      <Section style={{ margin: '24px 0' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse' as const }}>
+          <tbody>
+            {timestamp && (
+              <tr>
+                <td style={createTableCellStyle(true)}>Timestamp:</td>
+                <td style={createTableCellStyle(false, 'right')}>{timestamp}</td>
+              </tr>
+            )}
+            {typeof memoryPercentage === 'number' && (
+              <tr>
+                <td style={createTableCellStyle(true)}>Memory:</td>
+                <td style={createTableCellStyle(false, 'right')}>
+                  {memoryPercentage.toFixed(1)}%
+                  {typeof memoryUsed === 'number' && typeof memoryTotal === 'number' && (
+                    <> ({memoryUsed} / {memoryTotal})</>
+                  )}
+                </td>
+              </tr>
+            )}
+            {error && (
+              <tr>
+                <td style={createTableCellStyle(true)}>Error:</td>
+                <td
+                  style={{
+                    ...createTableCellStyle(false, 'right'),
+                    fontFamily: 'monospace',
+                    color: ELEVA_COLORS.error,
+                  }}
+                >
+                  {error}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </Section>
+
+      <Section style={{ margin: '24px 0' }}>
+        <Text style={ELEVA_TEXT_STYLES.bodyRegular}>
+          Please investigate and confirm the root cause. This alert was sent automatically.
+        </Text>
+      </Section>
+    </EmailLayout>
+  );
+};
+
+export default SystemHealthAlertEmail;
+
+SystemHealthAlertEmail.PreviewProps = {
+  status: 'unhealthy',
+  environment: 'production',
+  error: 'Redis connection timeout after 5000ms',
+  timestamp: '2026-04-20T08:30:00.000Z',
+  memoryPercentage: 87.4,
+  memoryUsed: 2800,
+  memoryTotal: 3200,
+  locale: 'en',
+} as SystemHealthAlertEmailProps;

--- a/lib/integrations/novu/email-service.ts
+++ b/lib/integrations/novu/email-service.ts
@@ -6,11 +6,14 @@ import AppointmentConfirmationTemplate from '@/emails/appointments/appointment-c
 import { AppointmentReminderEmail } from '@/emails/appointments/appointment-reminder';
 import ExpertNewAppointmentTemplate from '@/emails/experts/expert-new-appointment';
 import { ExpertNotificationEmail } from '@/emails/experts/expert-notification';
+import MarketplaceEventEmail from '@/emails/experts/marketplace-event';
+import SystemHealthAlertEmail from '@/emails/system/system-health-alert';
 import { ExpertPayoutNotificationTemplate, RefundNotificationTemplate } from '@/emails/payments';
 import MultibancoBookingPendingTemplate from '@/emails/payments/multibanco-booking-pending';
 import MultibancoPaymentReminderTemplate from '@/emails/payments/multibanco-payment-reminder';
 import PaymentConfirmationTemplate from '@/emails/payments/payment-confirmation';
 import ReservationExpiredEmail from '@/emails/payments/reservation-expired';
+import PackPurchaseConfirmationTemplate from '@/emails/packs/pack-purchase-confirmation';
 import WelcomeEmailTemplate from '@/emails/users/welcome-email';
 import { normalizeLocale, type SupportedLocale } from '@/emails/utils/i18n';
 import { generateAppointmentEmail, sendEmail } from '@/lib/integrations/novu/email';
@@ -223,11 +226,6 @@ interface EmailGenerationResult {
   html: string;
   text: string;
   subject: string;
-}
-
-interface TriggerWorkflowPayload {
-  subscriberId: string;
-  [key: string]: unknown;
 }
 
 /**
@@ -446,6 +444,15 @@ export class TemplateSelectionService {
         },
         expert: {
           default: asTemplate(ReservationExpiredEmail),
+        },
+      },
+    },
+
+    'pack-purchase-confirmation': {
+      default: {
+        patient: {
+          default: PackPurchaseConfirmationTemplate,
+          branded: PackPurchaseConfirmationTemplate,
         },
       },
     },
@@ -669,6 +676,63 @@ const propAdapters: Record<string, Record<string, Record<string, PropAdapter>>> 
         locale: data.locale,
       }),
     },
+    // `cancelled` / `default` events fall back to the AppointmentConfirmation
+    // template (per templateMappings). Use the same prop shape as `confirmed`
+    // so empty cells / placeholder leaks don't sneak in via passThrough.
+    cancelled: {
+      patient: (data) => ({
+        expertName: data.expertName,
+        clientName: data.customerName ?? data.clientName,
+        appointmentDate: data.appointmentDate,
+        appointmentTime: data.appointmentTime,
+        timezone: data.timezone,
+        appointmentDuration: data.appointmentDuration,
+        eventTitle: data.serviceName ?? data.eventTitle,
+        meetLink: data.meetingUrl ?? data.meetLink,
+        notes: data.notes,
+        locale: data.locale,
+      }),
+      expert: (data) => ({
+        expertName: data.expertName,
+        clientName: data.customerName ?? data.clientName,
+        clientPhone: data.clientPhone,
+        appointmentDate: data.appointmentDate,
+        appointmentTime: data.appointmentTime,
+        timezone: data.timezone,
+        appointmentDuration: data.appointmentDuration,
+        eventTitle: data.serviceName ?? data.eventTitle,
+        meetLink: data.meetingUrl ?? data.meetLink,
+        notes: data.notes,
+        locale: data.locale,
+      }),
+    },
+    default: {
+      patient: (data) => ({
+        expertName: data.expertName,
+        clientName: data.customerName ?? data.clientName,
+        appointmentDate: data.appointmentDate,
+        appointmentTime: data.appointmentTime,
+        timezone: data.timezone,
+        appointmentDuration: data.appointmentDuration,
+        eventTitle: data.serviceName ?? data.eventTitle,
+        meetLink: data.meetingUrl ?? data.meetLink,
+        notes: data.notes,
+        locale: data.locale,
+      }),
+      expert: (data) => ({
+        expertName: data.expertName,
+        clientName: data.customerName ?? data.clientName,
+        clientPhone: data.clientPhone,
+        appointmentDate: data.appointmentDate,
+        appointmentTime: data.appointmentTime,
+        timezone: data.timezone,
+        appointmentDuration: data.appointmentDuration,
+        eventTitle: data.serviceName ?? data.eventTitle,
+        meetLink: data.meetingUrl ?? data.meetLink,
+        notes: data.notes,
+        locale: data.locale,
+      }),
+    },
   },
   'payment-universal': {
     // app/api/webhooks/stripe/handlers/payment.ts → flatten appointmentDetails
@@ -732,6 +796,33 @@ const propAdapters: Record<string, Record<string, Record<string, PropAdapter>>> 
         };
       },
     },
+    // `pending` routes to the MultibancoBookingPendingTemplate per
+    // templateMappings — flatten appointmentDetails into the Multibanco prop
+    // names the template expects (entity / reference / amount / expires /
+    // hostedVoucherUrl). Fired by `handlePaymentIntentRequiresAction` for
+    // freshly created vouchers and by `handlePaymentIntentProcessing` for
+    // vouchers that hit the 4-day buffer window.
+    pending: {
+      patient: (data) => {
+        const details = (data.appointmentDetails as Record<string, unknown> | undefined) ?? {};
+        return {
+          customerName: data.customerName,
+          expertName: details.expert,
+          serviceName: details.service,
+          appointmentDate: details.date,
+          appointmentTime: details.time,
+          timezone: data.timezone,
+          duration: details.duration,
+          multibancoEntity: data.multibancoEntity,
+          multibancoReference: data.multibancoReference,
+          multibancoAmount: data.amount,
+          voucherExpiresAt: data.expiresAt,
+          hostedVoucherUrl: data.hostedVoucherUrl,
+          customerNotes: data.customerNotes,
+          locale: data.locale,
+        };
+      },
+    },
   },
   'multibanco-payment-reminder': {
     // app/api/cron/send-payment-reminders/route.ts uses these eventTypes.
@@ -783,6 +874,129 @@ const propAdapters: Record<string, Record<string, Record<string, PropAdapter>>> 
         notificationMessage: data.message ?? data.notificationMessage,
         actionUrl: data.actionUrl,
         actionText: data.actionText,
+      }),
+    },
+  },
+  'pack-purchase-confirmation': {
+    // Workflow payload is already built to match the template's prop names
+    // (see `app/api/webhooks/stripe/route.ts` `handlePackPurchase`), so this
+    // is effectively pass-through. Kept explicit so future renames trigger a
+    // test failure instead of a silent passthrough fallback.
+    default: {
+      patient: (data) => ({
+        buyerName: data.buyerName,
+        buyerEmail: data.buyerEmail,
+        packName: data.packName,
+        eventName: data.eventName,
+        expertName: data.expertName,
+        sessionsCount: data.sessionsCount,
+        promotionCode: data.promotionCode,
+        expiresAt: data.expiresAt,
+        bookingUrl: data.bookingUrl,
+        locale: data.locale,
+      }),
+    },
+  },
+  // Direct workflow → AppointmentConfirmationTemplate. Called from
+  // `triggerExpertAppointmentConfirmation` in `server/actions/meetings.ts`
+  // for the expert side of the booking. Payload is already shaped for the
+  // template; adapter is identity but kept explicit to match the
+  // configuration-gap warning policy.
+  'appointment-confirmation': {
+    default: {
+      patient: (data) => ({
+        expertName: data.expertName,
+        clientName: data.clientName,
+        appointmentDate: data.appointmentDate,
+        appointmentTime: data.appointmentTime,
+        timezone: data.timezone,
+        appointmentDuration: data.appointmentDuration,
+        eventTitle: data.eventTitle,
+        meetLink: data.meetLink,
+        notes: data.notes,
+        locale: data.locale,
+      }),
+      expert: (data) => ({
+        expertName: data.expertName,
+        clientName: data.clientName,
+        clientPhone: data.clientPhone,
+        appointmentDate: data.appointmentDate,
+        appointmentTime: data.appointmentTime,
+        timezone: data.timezone,
+        appointmentDuration: data.appointmentDuration,
+        eventTitle: data.eventTitle,
+        meetLink: data.meetLink,
+        notes: data.notes,
+        locale: data.locale,
+      }),
+    },
+  },
+  // Direct workflow → MultibancoBookingPendingTemplate. Triggered from
+  // `app/api/webhooks/stripe/handlers/payment.ts` `handlePaymentIntentRequiresAction`.
+  // Payload already matches the template's props.
+  'multibanco-booking-pending': {
+    default: {
+      patient: (data) => ({
+        customerName: data.customerName,
+        expertName: data.expertName,
+        serviceName: data.serviceName,
+        appointmentDate: data.appointmentDate,
+        appointmentTime: data.appointmentTime,
+        timezone: data.timezone,
+        duration: data.duration,
+        multibancoEntity: data.multibancoEntity,
+        multibancoReference: data.multibancoReference,
+        multibancoAmount: data.multibancoAmount,
+        voucherExpiresAt: data.voucherExpiresAt,
+        hostedVoucherUrl: data.hostedVoucherUrl,
+        customerNotes: data.customerNotes,
+        locale: data.locale,
+      }),
+    },
+  },
+  // Direct workflow → ReservationExpiredEmail. Patient-only per the
+  // workflow's early-return; expert mapping kept for safety/symmetry.
+  'reservation-expired': {
+    default: {
+      patient: (data) => ({
+        recipientName: data.clientName ?? data.recipientName,
+        recipientType: 'patient' as const,
+        expertName: data.expertName,
+        serviceName: data.serviceName,
+        appointmentDate: data.appointmentDate,
+        appointmentTime: data.appointmentTime,
+        timezone: data.timezone,
+        locale: data.locale,
+      }),
+      expert: (data) => ({
+        recipientName: data.expertName ?? data.recipientName,
+        recipientType: 'expert' as const,
+        expertName: data.expertName,
+        serviceName: data.serviceName,
+        appointmentDate: data.appointmentDate,
+        appointmentTime: data.appointmentTime,
+        timezone: data.timezone,
+        locale: data.locale,
+      }),
+    },
+  },
+  // user-lifecycle currently only renders the welcome email body for the
+  // `welcome` / `user-created` event types (everything else is rejected
+  // by the workflow's defensive guard). Identity adapter, but explicit
+  // so the contract is asserted by tests.
+  'user-lifecycle': {
+    welcome: {
+      patient: (data) => ({
+        userName: data.userName ?? data.firstName,
+        firstName: data.firstName ?? data.userName,
+        dashboardUrl: data.dashboardUrl ?? '/dashboard',
+        locale: data.locale,
+      }),
+      expert: (data) => ({
+        userName: data.userName ?? data.firstName,
+        firstName: data.firstName ?? data.userName,
+        dashboardUrl: data.dashboardUrl ?? '/dashboard',
+        locale: data.locale,
       }),
     },
   },
@@ -1124,35 +1338,13 @@ export async function getSubscriberForEmail(clerkUserId: string) {
   }
 }
 
-export async function triggerNovuWorkflow(workflowId: string, payload: TriggerWorkflowPayload) {
-  if (!novu) {
-    const errorMsg = `[Novu Email Service] Cannot trigger workflow ${workflowId}: ${initializationError || 'client not initialized'}`;
-    console.error(errorMsg);
-    throw new Error(initializationError || 'Novu client not initialized');
-  }
-
-  try {
-    console.log('[Novu Email Service] 🔔 Triggering workflow:', {
-      workflowId,
-      subscriberId: payload.subscriberId,
-    });
-
-    const result = await novu.trigger({
-      workflowId,
-      to: payload.subscriberId,
-      payload,
-    });
-
-    console.log('[Novu Email Service] ✅ Successfully triggered workflow:', workflowId);
-    return result;
-  } catch (error) {
-    console.error('[Novu Email Service] ❌ Failed to trigger workflow:', {
-      workflowId,
-      error: error instanceof Error ? error.message : 'Unknown error',
-    });
-    throw error;
-  }
-}
+// `triggerNovuWorkflow` was previously exported here with a `to: string`
+// signature that conflicted with the canonical version in
+// `lib/integrations/novu/utils.ts` (`to: subscriber`). The package barrel
+// re-exports the utils version so this duplicate had zero production
+// callers but lived as a footgun for anyone importing from this file
+// directly. Removed in the 2026-04 audit. Use `triggerNovuWorkflow` from
+// `@/lib/integrations/novu` (or `@/lib/integrations/novu/utils`) instead.
 
 /**
  * Enhanced email rendering service for existing React Email templates
@@ -1418,11 +1610,11 @@ export class ElevaEmailService {
       '@/emails/appointments/appointment-reminder'
     );
 
-    // The reminder template only ships `en` and `pt` translations, so
-    // collapse `es` / `br` (and anything else `normalizeLocale` produced)
-    // down to `pt` for Portuguese-family locales and `en` otherwise.
-    const normalized: SupportedLocale = normalizeLocale(data.locale);
-    const locale: 'en' | 'pt' = normalized === 'pt' || normalized === 'br' ? 'pt' : 'en';
+    // The reminder template now ships full translations for every
+    // SupportedLocale (en / pt / es / br), so we can pass the normalized
+    // locale through directly. No more collapsing es/br patients to
+    // English reminders.
+    const locale: SupportedLocale = normalizeLocale(data.locale);
 
     const template = React.createElement(AppointmentReminderTemplate, {
       patientName: data.userName,
@@ -1824,6 +2016,151 @@ export class ElevaEmailService {
       appointmentTime: data.appointmentTime,
       timezone: data.timezone || 'UTC',
       locale,
+    });
+
+    return render(template);
+  }
+
+  /**
+   * Render the pack-purchase confirmation email. Triggered after a session
+   * pack is purchased through Stripe Checkout — the buyer gets the promo
+   * code that unlocks `sessionsCount` future bookings with the expert.
+   *
+   * @example
+   * ```typescript
+   * const html = await elevaEmailService.renderPackPurchase({
+   *   buyerName: 'Marta Carvalho',
+   *   buyerEmail: 'marta@example.com',
+   *   packName: '5-session pack',
+   *   eventName: 'Physiotherapy session',
+   *   expertName: 'Patricia Mota',
+   *   sessionsCount: 5,
+   *   promotionCode: 'PACK-XYZ-123',
+   *   expiresAt: '2026-12-31T23:59:59.000Z',
+   *   bookingUrl: 'https://eleva.care/en/patricia-mota',
+   *   locale: 'en',
+   * });
+   * ```
+   */
+  async renderPackPurchase(data: {
+    buyerName: string;
+    buyerEmail: string;
+    packName: string;
+    eventName: string;
+    expertName: string;
+    sessionsCount: number;
+    promotionCode: string;
+    expiresAt: string;
+    bookingUrl: string;
+    locale?: string;
+  }) {
+    // The pack template implements `en`, `pt`, `es` (with `pt-BR` collapsed
+    // to `pt` inside the template via prefix matching). We still normalize
+    // here so regional tags map cleanly and Brazilian Portuguese hits the
+    // `pt` translations explicitly.
+    const normalized: SupportedLocale = normalizeLocale(data.locale);
+    const locale: 'en' | 'pt' | 'es' =
+      normalized === 'br' ? 'pt' : normalized === 'es' ? 'es' : normalized === 'pt' ? 'pt' : 'en';
+
+    recordRenderBreadcrumb({
+      workflowId: 'pack-purchase-confirmation',
+      eventType: 'default',
+      templateName: 'PackPurchaseConfirmation',
+      data: data as unknown as Record<string, unknown>,
+    });
+
+    const template = React.createElement(PackPurchaseConfirmationTemplate, {
+      buyerName: data.buyerName,
+      buyerEmail: data.buyerEmail,
+      packName: data.packName,
+      eventName: data.eventName,
+      expertName: data.expertName,
+      sessionsCount: data.sessionsCount,
+      promotionCode: data.promotionCode,
+      expiresAt: data.expiresAt,
+      bookingUrl: data.bookingUrl,
+      locale,
+    });
+
+    return render(template);
+  }
+
+  /**
+   * Render the marketplace-event email used by the `marketplace-universal`
+   * Novu workflow. Replaces the inline HTML body that previously shipped
+   * unbranded for `payment-received`, `payout-processed`,
+   * `connect-account-status`, and `refund-processed` events.
+   */
+  async renderMarketplaceEvent(data: {
+    expertName?: string;
+    message?: string;
+    amount?: string;
+    currency?: string;
+    accountStatus?: string;
+    eventType?:
+      | 'payment-received'
+      | 'payout-processed'
+      | 'connect-account-status'
+      | 'refund-processed';
+    actionUrl?: string;
+    actionText?: string;
+    locale?: string;
+  }) {
+    const normalized: SupportedLocale = normalizeLocale(data.locale);
+
+    recordRenderBreadcrumb({
+      workflowId: 'marketplace-universal',
+      eventType: data.eventType ?? 'payment-received',
+      templateName: 'MarketplaceEventEmail',
+      data: data as unknown as Record<string, unknown>,
+    });
+
+    const template = React.createElement(MarketplaceEventEmail, {
+      expertName: data.expertName,
+      message: data.message,
+      amount: data.amount,
+      currency: data.currency,
+      accountStatus: data.accountStatus,
+      eventType: data.eventType,
+      actionUrl: data.actionUrl,
+      actionText: data.actionText,
+      locale: normalized,
+    });
+
+    return render(template);
+  }
+
+  /**
+   * Render the system-health-alert email used by the `system-health` Novu
+   * workflow (admin-facing). Replaces the inline HTML body in
+   * `config/novu.ts`.
+   */
+  async renderSystemHealthAlert(data: {
+    status: 'healthy' | 'unhealthy';
+    environment: string;
+    error?: string;
+    timestamp?: string;
+    memory?: { used: number; total: number; percentage: number };
+    locale?: string;
+  }) {
+    const normalized: SupportedLocale = normalizeLocale(data.locale);
+
+    recordRenderBreadcrumb({
+      workflowId: 'system-health',
+      eventType: 'health-check-failure',
+      templateName: 'SystemHealthAlertEmail',
+      data: data as unknown as Record<string, unknown>,
+    });
+
+    const template = React.createElement(SystemHealthAlertEmail, {
+      status: data.status,
+      environment: data.environment,
+      error: data.error,
+      timestamp: data.timestamp,
+      memoryPercentage: data.memory?.percentage,
+      memoryUsed: data.memory?.used,
+      memoryTotal: data.memory?.total,
+      locale: normalized,
     });
 
     return render(template);

--- a/lib/integrations/novu/utils.ts
+++ b/lib/integrations/novu/utils.ts
@@ -592,6 +592,14 @@ export const STRIPE_EVENT_TO_WORKFLOW_MAPPINGS = {
   // Payment events - use universal workflow with eventType
   // NOTE: payment_intent.succeeded removed - email sent directly via Resend in handlePaymentSucceeded()
   'payment_intent.payment_failed': 'payment-universal', // Uses eventType: 'failed'
+  // payment_intent.processing fires after a Multibanco voucher's payment
+  // window closes — Stripe holds funds in a 4-day buffer before either
+  // succeeding or failing. We want to surface this to the patient so they
+  // know not to re-pay the voucher.
+  'payment_intent.processing': 'payment-universal', // Uses eventType: 'pending'
+  // payment_intent.canceled lets us release the slot reservation early
+  // when the customer (or our cron job) explicitly cancels a pending PI.
+  'payment_intent.canceled': 'payment-universal', // Uses eventType: 'cancelled'
   'charge.refunded': 'payment-universal', // Uses eventType: 'refund'
 
   // Subscription events - use payment universal workflow
@@ -599,12 +607,26 @@ export const STRIPE_EVENT_TO_WORKFLOW_MAPPINGS = {
   'customer.subscription.updated': 'payment-universal', // Uses eventType: 'success'
   'customer.subscription.deleted': 'payment-universal', // Uses eventType: 'cancelled'
 
-  // Invoice events - use payment universal workflow
-  'invoice.payment_succeeded': 'payment-universal', // Uses eventType: 'success'
+  // Invoice events - use payment universal workflow.
+  // `invoice.paid` is Stripe's modern event for "an invoice was paid" and
+  // matches what the production webhook subscribes to (the older
+  // `invoice.payment_succeeded` is still emitted but is being phased out).
+  // No subscription product exists yet — kept here for forward
+  // compatibility when subscriptions land.
+  'invoice.paid': 'payment-universal', // Uses eventType: 'success'
   'invoice.payment_failed': 'payment-universal', // Uses eventType: 'failed'
 
-  // Dispute events - use payment universal workflow
-  'charge.dispute.created': 'payment-universal', // Uses eventType: 'dispute'
+  // Dispute events - use payment universal workflow. Stripe explicitly
+  // recommends listening for status changes (won/lost/closed) on top of
+  // the initial `created` event so internal state stays in sync.
+  'charge.dispute.created': 'payment-universal', // Uses eventType: 'disputed'
+  'charge.dispute.updated': 'payment-universal', // Uses eventType: 'disputed'
+  'charge.dispute.closed': 'payment-universal', // Uses eventType: 'disputed'
+
+  // Refund object events — `refund.updated` is the modern equivalent of
+  // `charge.refund.updated` and fires on Refund objects directly. Pair
+  // with `charge.refunded` to catch failed refunds.
+  'refund.updated': 'payment-universal', // Uses eventType: 'refunded'
 
   // Connect account events - use expert management workflow
   'account.updated': 'expert-management', // Uses eventType: 'connect-account-status'
@@ -621,14 +643,23 @@ export const STRIPE_EVENT_TO_WORKFLOW_MAPPINGS = {
 const STRIPE_TO_PAYMENT_EVENT_TYPE: Record<string, string> = {
   // NOTE: payment_intent.succeeded removed - email sent directly via Resend
   'payment_intent.payment_failed': 'failed',
+  'payment_intent.processing': 'pending',
+  'payment_intent.canceled': 'cancelled',
   'charge.refunded': 'refunded',
+  'refund.updated': 'refunded',
   'checkout.session.completed': 'confirmed',
   'customer.subscription.created': 'confirmed',
   'customer.subscription.updated': 'confirmed',
   'customer.subscription.deleted': 'cancelled',
+  // `invoice.paid` is Stripe's modern event; matches the Dashboard
+  // subscription. Old `invoice.payment_succeeded` kept as fallback for
+  // legacy webhook configs.
+  'invoice.paid': 'success',
   'invoice.payment_succeeded': 'success',
   'invoice.payment_failed': 'failed',
   'charge.dispute.created': 'disputed',
+  'charge.dispute.updated': 'disputed',
+  'charge.dispute.closed': 'disputed',
 };
 
 /**

--- a/lib/integrations/novu/utils.ts
+++ b/lib/integrations/novu/utils.ts
@@ -611,9 +611,12 @@ export const STRIPE_EVENT_TO_WORKFLOW_MAPPINGS = {
   // `invoice.paid` is Stripe's modern event for "an invoice was paid" and
   // matches what the production webhook subscribes to (the older
   // `invoice.payment_succeeded` is still emitted but is being phased out).
-  // No subscription product exists yet — kept here for forward
-  // compatibility when subscriptions land.
+  // Both keys are mapped so `getWorkflowFromStripeEvent()` resolves
+  // either incoming event name (legacy webhook configs, test triggers,
+  // older endpoint subscriptions). No subscription product exists yet —
+  // kept here for forward compatibility when subscriptions land.
   'invoice.paid': 'payment-universal', // Uses eventType: 'success'
+  'invoice.payment_succeeded': 'payment-universal', // Uses eventType: 'success' (legacy)
   'invoice.payment_failed': 'payment-universal', // Uses eventType: 'failed'
 
   // Dispute events - use payment universal workflow. Stripe explicitly

--- a/lib/notifications/core.ts
+++ b/lib/notifications/core.ts
@@ -43,19 +43,29 @@ export async function createUserNotification(params: CreateNotificationParams): 
         break;
 
       case NOTIFICATION_TYPE_ACCOUNT_UPDATE:
-        // Note: This was previously used for payment notifications with eventType: 'welcome'
-        // which incorrectly sent welcome emails. Changed to 'account-updated' for proper usage.
+        // ACCOUNT_UPDATE is exclusively used for expert-side notifications
+        // (payment failure / refund / connect-account changes). Routing
+        // through `user-lifecycle` would trigger its welcome-email step
+        // and ship a "Welcome to Eleva Care!" body for events that have
+        // nothing to do with onboarding — that was the original placeholder-
+        // leak bug class. The right destination is `expert-management`
+        // with `notificationType: 'account-update'`, which renders
+        // `ExpertNotificationEmail` (a generic branded notification card)
+        // and uses the supplied `message` / `actionUrl` verbatim.
         await triggerWorkflow({
-          workflowId: 'user-lifecycle',
+          workflowId: 'expert-management',
           to: {
             subscriberId: userId,
             ...(data.email ? { email: data.email as string } : {}),
             ...(data.firstName ? { firstName: data.firstName as string } : {}),
           },
           payload: {
-            eventType: 'account-updated',
-            userName: (data.userName as string) || 'User',
-            ...data,
+            notificationType: 'account-update',
+            expertName: (data.userName as string) || (data.firstName as string) || 'Expert',
+            message: (data.message as string) || (data.title as string) || 'Account update',
+            actionUrl: (data.actionUrl as string) || undefined,
+            actionText: (data.actionText as string) || undefined,
+            locale: (data.locale as string) || 'en',
           },
         });
         break;

--- a/tests/lib/integrations/novu/email-service.test.ts
+++ b/tests/lib/integrations/novu/email-service.test.ts
@@ -654,6 +654,219 @@ describe('PropAdapter — workflow payload → template props', () => {
     });
   });
 
+  test('appointment-universal.cancelled.patient: explicit identity-style adapter (no passthrough)', () => {
+    const adapter = getPropAdapter({
+      workflowId: 'appointment-universal',
+      eventType: 'cancelled',
+      userSegment: 'patient',
+      locale: 'en',
+      templateVariant: 'default',
+    });
+
+    const adapted = adapter({
+      customerName: 'Marta',
+      expertName: 'Patricia',
+      serviceName: 'Physio',
+      appointmentDate: 'Tomorrow',
+      appointmentTime: '10:00',
+      timezone: 'Europe/Lisbon',
+      meetingUrl: 'https://meet.google.com/abc',
+      locale: 'en',
+    });
+
+    expect(adapted).toMatchObject({
+      clientName: 'Marta',
+      expertName: 'Patricia',
+      eventTitle: 'Physio',
+      meetLink: 'https://meet.google.com/abc',
+    });
+  });
+
+  test('payment-universal.pending.patient: flattens appointmentDetails + Multibanco fields', () => {
+    const adapter = getPropAdapter({
+      workflowId: 'payment-universal',
+      eventType: 'pending',
+      userSegment: 'patient',
+      locale: 'pt',
+      templateVariant: 'default',
+    });
+
+    const adapted = adapter({
+      customerName: 'Marta',
+      amount: '70.00',
+      multibancoEntity: '12345',
+      multibancoReference: '999000111',
+      expiresAt: '2026-04-27T23:59:59.000Z',
+      hostedVoucherUrl: 'https://stripe.com/voucher/abc',
+      timezone: 'Europe/Lisbon',
+      appointmentDetails: {
+        service: 'Physio',
+        expert: 'Patricia',
+        date: 'Tomorrow',
+        time: '10:00',
+        duration: 60,
+      },
+      locale: 'pt',
+    });
+
+    expect(adapted).toMatchObject({
+      customerName: 'Marta',
+      expertName: 'Patricia',
+      serviceName: 'Physio',
+      appointmentDate: 'Tomorrow',
+      appointmentTime: '10:00',
+      multibancoEntity: '12345',
+      multibancoReference: '999000111',
+      multibancoAmount: '70.00',
+      voucherExpiresAt: '2026-04-27T23:59:59.000Z',
+      hostedVoucherUrl: 'https://stripe.com/voucher/abc',
+    });
+  });
+
+  test('appointment-confirmation.default.expert: forwards every payload field including clientPhone', () => {
+    const adapter = getPropAdapter({
+      workflowId: 'appointment-confirmation',
+      eventType: 'default',
+      userSegment: 'expert',
+      locale: 'en',
+      templateVariant: 'default',
+    });
+
+    const adapted = adapter({
+      expertName: 'Patricia',
+      clientName: 'Marta',
+      clientPhone: '+351900000000',
+      appointmentDate: 'Tomorrow',
+      appointmentTime: '10:00',
+      timezone: 'Europe/Lisbon',
+      appointmentDuration: '45 minutes',
+      eventTitle: 'Physio',
+      meetLink: 'https://meet.google.com/abc',
+      locale: 'en',
+    });
+
+    expect(adapted).toMatchObject({
+      expertName: 'Patricia',
+      clientName: 'Marta',
+      clientPhone: '+351900000000',
+      eventTitle: 'Physio',
+      meetLink: 'https://meet.google.com/abc',
+    });
+  });
+
+  test('multibanco-booking-pending.default.patient: explicit pass-through adapter', () => {
+    const adapter = getPropAdapter({
+      workflowId: 'multibanco-booking-pending',
+      eventType: 'default',
+      userSegment: 'patient',
+      locale: 'pt',
+      templateVariant: 'default',
+    });
+
+    const adapted = adapter({
+      customerName: 'Marta',
+      expertName: 'Patricia',
+      serviceName: 'Physio',
+      multibancoEntity: '12345',
+      multibancoReference: '999000111',
+      multibancoAmount: '70.00',
+      voucherExpiresAt: '2026-04-27T23:59:59.000Z',
+      hostedVoucherUrl: 'https://stripe.com/voucher/abc',
+      locale: 'pt',
+    });
+
+    expect(adapted).toMatchObject({
+      customerName: 'Marta',
+      multibancoEntity: '12345',
+      multibancoAmount: '70.00',
+    });
+  });
+
+  test('reservation-expired.default.patient: maps clientName→recipientName with patient recipientType', () => {
+    const adapter = getPropAdapter({
+      workflowId: 'reservation-expired',
+      eventType: 'default',
+      userSegment: 'patient',
+      locale: 'pt',
+      templateVariant: 'default',
+    });
+
+    const adapted = adapter({
+      expertName: 'Patricia',
+      clientName: 'Marta',
+      serviceName: 'Physio',
+      appointmentDate: 'Tomorrow',
+      appointmentTime: '10:00',
+      timezone: 'Europe/Lisbon',
+      locale: 'pt',
+    });
+
+    expect(adapted).toMatchObject({
+      recipientName: 'Marta',
+      recipientType: 'patient',
+      expertName: 'Patricia',
+      serviceName: 'Physio',
+    });
+  });
+
+  test('user-lifecycle.welcome.patient: identity-style adapter with dashboardUrl default', () => {
+    const adapter = getPropAdapter({
+      workflowId: 'user-lifecycle',
+      eventType: 'welcome',
+      userSegment: 'patient',
+      locale: 'en',
+      templateVariant: 'default',
+    });
+
+    const adapted = adapter({
+      userName: 'Marta',
+      firstName: 'Marta',
+      locale: 'en',
+    });
+
+    expect(adapted).toMatchObject({
+      userName: 'Marta',
+      firstName: 'Marta',
+      dashboardUrl: '/dashboard',
+    });
+  });
+
+  test('pack-purchase-confirmation.default.patient: forwards every payload field', () => {
+    const adapter = getPropAdapter({
+      workflowId: 'pack-purchase-confirmation',
+      eventType: 'default',
+      userSegment: 'patient',
+      locale: 'pt',
+      templateVariant: 'default',
+    });
+
+    const adapted = adapter({
+      buyerName: 'Marta Carvalho',
+      buyerEmail: 'marta@example.com',
+      packName: '5-session physio pack',
+      eventName: 'Physiotherapy session',
+      expertName: 'Patricia Mota',
+      sessionsCount: 5,
+      promotionCode: 'PACK-XYZ-123',
+      expiresAt: '2026-12-31T23:59:59.000Z',
+      bookingUrl: 'https://eleva.care/en/patricia-mota',
+      locale: 'pt',
+    });
+
+    expect(adapted).toMatchObject({
+      buyerName: 'Marta Carvalho',
+      buyerEmail: 'marta@example.com',
+      packName: '5-session physio pack',
+      eventName: 'Physiotherapy session',
+      expertName: 'Patricia Mota',
+      sessionsCount: 5,
+      promotionCode: 'PACK-XYZ-123',
+      expiresAt: '2026-12-31T23:59:59.000Z',
+      bookingUrl: 'https://eleva.care/en/patricia-mota',
+      locale: 'pt',
+    });
+  });
+
   test('unregistered (workflowId, eventType, userSegment) returns identity adapter', () => {
     const adapter = getPropAdapter({
       workflowId: 'unknown-workflow',


### PR DESCRIPTION
Comprehensive audit of every emails/* template, every workflow in config/novu.ts, every triggerWorkflow callsite (webhooks/crons/payment-intent/pack-checkout/ googleCalendar), and the Stripe-event-to-workflow map across three webhook endpoints (/stripe, /stripe-identity, /stripe-connect). Resolves 13 findings spanning P0 (wrong-template emails) through P3 (cleanup); zero remaining manual action items.

P0 — wrong-template emails

* lib/notifications/core.ts: route NOTIFICATION_TYPE_ACCOUNT_UPDATE through expert-management.account-update (renders ExpertNotificationEmail) instead of user-lifecycle (which always rendered the welcome-email body). Expert payment-failure / refund / connect-account-status notifications no longer ship a "Welcome to Eleva Care!" subject + body.
* config/novu.ts: defensive guard in userLifecycleWorkflow.step.email that short-circuits non-welcome eventTypes so a future stray trigger can't reintroduce the bug.

P1 — pack-purchase Novu workflow

* New pack-purchase-confirmation Novu workflow + renderPackPurchase method
  + propAdapter row + regression test (35/35 → 46/46 with full suite).
* Stripe webhook handlePackPurchase now triggers the workflow instead of calling Resend sendEmail directly — preserves in-app notification, idempotency, template selection, and prop-adapter contract.
* New WORKFLOW_IDS.PACK_PURCHASE_CONFIRMATION constant.

P1 — Stripe webhook event coverage

* New handlers in payment.ts: handlePaymentIntentProcessing, handlePaymentIntentCanceled, handleDisputeUpdated.
* New cases in route.ts switch for: payment_intent.processing, payment_intent.canceled, charge.dispute.updated, charge.dispute.closed, refund.updated.
* STRIPE_EVENT_TO_WORKFLOW_MAPPINGS and STRIPE_TO_PAYMENT_EVENT_TYPE updated; invoice.paid / invoice.payment_succeeded both supported (Stripe's modern event aligned with Dashboard subscription).

P2 — defensive rendering + locale + adapter gaps

* Multibanco entity/reference/amount/expires/service/expert rows in multibanco-booking-pending.tsx and multibanco-payment-reminder.tsx now wrapped in truthy guards (same defensive-render bug class fixed elsewhere previously).
* appointment-reminder.tsx heading/banner/preview/subject use safeAppointmentType derived value.
* pack-purchase-confirmation.tsx previewText and promo Section both gated on promotionCode.
* 6 new explicit propAdapter rows for previously passthrough triples: appointment-universal.{cancelled,default}, payment-universal.pending, appointment-confirmation.default, multibanco-booking-pending, reservation-expired, user-lifecycle.welcome — plus 6 regression tests.
* appointment-reminder.tsx ships full es and br translations; locale prop widened to mirror SupportedLocale; email-service caller no longer collapses es/br patients to English reminders.

P3 — cleanup

* config/novu-workflows.ts: removed 5 dead constants (USER_LOGIN_NOTIFICATION, PAYMENT_SUCCESS, PAYMENT_FAILED, APPOINTMENT_REMINDER_24HR, EXPERT_ACCOUNT_UPDATED); routed legacy IDs through WORKFLOW_ID_MAPPINGS; added PACK_PURCHASE_CONFIRMATION + RESERVATION_EXPIRED to the registry.
* New emails/experts/marketplace-event.tsx and emails/system/system-health-alert.tsx React Email templates; marketplaceWorkflow + systemHealthWorkflow now render through them via new renderMarketplaceEvent / renderSystemHealthAlert methods (replaces inline-HTML email bodies).
* Removed duplicate triggerNovuWorkflow at the bottom of email-service.ts (zero callers, conflicting signature with the canonical utils.ts version).
* Documented the appointment-confirmation vs appointment-universal.confirmed split with a header comment in config/novu.ts.

Doc

* New docs/02-core-systems/notifications/09-email-system-audit-2026-04.md: 13-row findings table, post-audit architecture diagram, full Stripe-event ↔ workflow map, three-endpoint subscription reference (verified 2026-04-20), resolution-status tracker, and re-verification recipe for future drift detection.

Verification

* 386/386 Jest tests pass across all 34 suites (46/46 Novu-specific).
* Local pnpm build fails only at the static-prerender phase due to the local .env missing CLERK_PUBLISHABLE_KEY — unrelated to this change set (failing pages are /pt/trust/security and /pt-BR/legal/terms; will succeed in Vercel where the env var is set).

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced payment event notifications with support for payment processing and cancellation states
  * New system health alert email notifications for monitoring
  * Marketplace event notifications for payment and payout updates
  * Expanded language support including Spanish and Brazilian Portuguese

* **Bug Fixes**
  * Improved email rendering to gracefully handle missing or incomplete data in payment and appointment communications
  * Enhanced dispute and refund event tracking

* **Documentation**
  * Added comprehensive email system audit documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->